### PR TITLE
Listing dependencies in the default group & Multi_JSON

### DIFF
--- a/lib/que/job.rb
+++ b/lib/que/job.rb
@@ -1,4 +1,4 @@
-require 'json'
+require 'multi_json'
 
 module Que
   class Job
@@ -36,7 +36,7 @@ module Que
           args << options if options.any?
         end
 
-        attrs = {:job_class => to_s, :args => JSON.dump(args)}
+        attrs = {:job_class => to_s, :args => MultiJson.dump(args)}
 
         if t = run_at || @default_run_at && @default_run_at.call
           attrs[:run_at] = t
@@ -134,7 +134,7 @@ module Que
 
       def run_job(attrs)
         attrs = indifferentiate(attrs)
-        attrs[:args] = indifferentiate(JSON.load(attrs[:args]))
+        attrs[:args] = indifferentiate(MultiJson.load(attrs[:args]))
         const_get("::#{attrs[:job_class]}").new(attrs).tap(&:_run)
       end
 

--- a/que.gemspec
+++ b/que.gemspec
@@ -27,4 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'activerecord'
   spec.add_dependency 'pg'
   spec.add_dependency 'connection_pool'
+  spec.add_dependency 'multi_json', '~> 1.0'
 end


### PR DESCRIPTION
- Using [Multi_JSON](https://rubygems.org/gems/multi_json) so we always load the fastest possible JSON coder.
- Fixing the gemspec to list:
  - sequel
  - activerecord
  - pg
  - connection_pool

These should belong in the default group not development as they are stedfast requirements for the gem to function.

Ran all the tests and everything passed :smile: 
