### PR TITLE
added failing test for a job class that doesn't inherit from Que::Job

### DIFF
--- a/spec/unit/worker_spec.rb
+++ b/spec/unit/worker_spec.rb
@@ -162,4 +162,15 @@ describe Que::Worker do
       @worker.wait_until_stopped
     end
   end
+
+  it "should not continually try to re-run failing jobs" do
+    class J
+      def run
+        true
+      end
+    end
+    @worker = Que::Worker.new
+    Que::Job.enqueue job_class: 'J'
+    sleep_until { @worker.sleeping? }
+  end
 end


### PR DESCRIPTION
not sure what the correct resolution would be. 

right now, que tries to redo the job as fast as it can, which probably isn't the right thing.
