### PR TITLE
enqueue fails if underlying connection has been reconnected

### DIFF
--- a/lib/que/adapters/base.rb
+++ b/lib/que/adapters/base.rb
@@ -69,6 +69,7 @@ module Que
             conn.exec_prepared("que_#{name}", params)
           rescue ::PG::InvalidSqlStatementName => e
             unless prepared_just_now
+              Que.log :level => 'warn', :event => "Re-preparing statement que_#{name} which has disappeared"
               statements[name] = false
               retry
             end

--- a/spec/adapters/active_record_spec.rb
+++ b/spec/adapters/active_record_spec.rb
@@ -41,6 +41,14 @@ unless defined?(RUBY_ENGINE) && RUBY_ENGINE == 'jruby'
       it "should recreate the prepared statements" do
         expect { NonsenseJob.enqueue }.not_to raise_error
       end
+
+      it "should log this extraordinary event" do
+        NonsenseJob.enqueue
+        $logger.messages.count.should == 1
+        message = JSON.load($logger.messages.first)
+        message['lib'].should == 'que'
+        message['event'].should match %r{Re-preparing}
+      end
     end
 
     it "should instantiate args as ActiveSupport::HashWithIndifferentAccess" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -62,6 +62,11 @@ end
 def $logger.method_missing(m, message)
   $logger_mutex.synchronize { messages << message }
 end
+# Object includes Kernel#warn which is not what we expect, so remove:
+def $logger.warn(message)
+  method_missing(:warn, message)
+end
+
 
 
 


### PR DESCRIPTION
I've seen this a few times in the wild when using Amazon RDS:

```
PG::InvalidSqlStatementName: ERROR: prepared statement "que_insert_job" does not exist
[GEM_ROOT]/gems/que-0.7.0/lib/que/adapters/base.rb:68:in `exec_prepared`
[GEM_ROOT]/gems/que-0.7.0/lib/que/adapters/base.rb:68:in `block in execute_prepared`
[GEM_ROOT]/gems/que-0.7.0/lib/que/adapters/active_record.rb:5:in `block in checkout`
[GEM_ROOT]/gems/activerecord-4.0.3/lib/active_record/connection_adapters/abstract/connection_pool.rb:294:in `with_connection`
[GEM_ROOT]/gems/que-0.7.0/lib/que/adapters/active_record.rb:30:in `checkout_activerecord_adapter`
[GEM_ROOT]/gems/que-0.7.0/lib/que/adapters/active_record.rb:5:in `checkout`
[GEM_ROOT]/gems/que-0.7.0/lib/que/adapters/base.rb:60:in `execute_prepared`
[GEM_ROOT]/gems/que-0.7.0/lib/que/adapters/base.rb:43:in `execute`
[GEM_ROOT]/gems/que-0.7.0/lib/que.rb:44:in `execute`
[GEM_ROOT]/gems/que-0.7.0/lib/que/job.rb:62:in `enqueue`
```

This might also solve the problem I've been seeing sporadically where the queue workers stop working.  I have three unicorns, and sometimes none of them do any work on the queue.
