### PR TITLE
Support jobs in the far future

### DIFF
--- a/lib/que/sql.rb
+++ b/lib/que/sql.rb
@@ -48,7 +48,7 @@ module Que
     :set_error => %{
       UPDATE que_jobs
       SET error_count = $1::integer,
-          run_at      = now() + $2::integer * '1 second'::interval,
+          run_at      = now() + $2::bigint * '1 second'::interval,
           last_error  = $3::text
       WHERE queue     = $4::text
       AND   priority  = $5::smallint


### PR DESCRIPTION
As an aside, looks like there will be problems if the number of errors is greater than 2 billion. Hopefully that's never a problem for anyone, that's a lot of errors...  but possibly the `error_count::int`s in this file should be all bigints? If you have 2 billion jobs and each has an error, the job_stats query will fail.
