### PR TITLE
Added failing test case when `Que.mode = :sync' and using specific `run_at'

### DIFF
--- a/spec/unit/pool_spec.rb
+++ b/spec/unit/pool_spec.rb
@@ -75,6 +75,14 @@ describe "Managing the Worker pool" do
         ArgsJob.enqueue(5, :testing => "synchronous", :run_at => Time.now + 60)
         DB[:que_jobs].select_map(:job_class).should == ["ArgsJob"]
       end
+
+      it "should work fine with enqueuing jobs without a DB connection and with specific run_ats" do
+        Que.connection = nil
+        Que.mode = :sync
+
+        ArgsJob.enqueue(5, :testing => "synchronous", :run_at => Time.now + 60).should be_an_instance_of ArgsJob
+        $passed_args.should == [5, {:testing => "synchronous"}]
+      end
     end
 
     describe ":async" do


### PR DESCRIPTION
Hey there!

I'm really liking Que thus far - and have been playing around with the ActiveJob integration, but I _think_ I might've come across a bug when `Que.mode = :sync`.

I noticed that when the `Que.connection = nil` and `Que.mode = :sync` and you attempt to enqueue a job with a specific `run_at`, Que with throw a runtime error with the message "Que connection not established!". I added a failing test case in this commit to demonstrate.

I wanted to patch it too - but i'm not 100% sure where to start digging, or if it was even a bug (and not just me :smile:). I stumbled across this whilst adding support for `enqueue_at` in ActiveJob.
