### PR TITLE
Fix recurring docs example

### DIFF
--- a/docs/customizing_que.md
+++ b/docs/customizing_que.md
@@ -8,7 +8,7 @@ Que's support for scheduling jobs makes it easy to implement reliable recurring 
 
     class Cron < Que::Job
       def run
-        users = User.where(:created_at => @attrs[:run_at]...(@attrs[:run_at] + 1.hour))
+        users = User.where(:created_at => (@attrs[:run_at] - 1.hour)...@attrs[:run_at])
         # Do something with users.
 
         ActiveRecord::Base.transaction do


### PR DESCRIPTION
Also, I notice that the example doesn't work if there's a job failure (as run_at would change). I think to do this properly, you'd want to put in the time range the users should be checked in the job args. Or, we could add a 'created_at' timestamptz to the que_jobs table and use that to figure out the range of time -- as that wouldn't change if there's a failure.
