### PR TITLE
Replaced timestampz to timestamp for run_at

### DIFF
--- a/docs/customizing_que.md
+++ b/docs/customizing_que.md
@@ -88,7 +88,7 @@ Que deletes jobs from the queue as they are worked, in order to keep the `que_jo
 
     class MyJobClass < Que::Job
       def destroy
-        Que.execute "INSERT INTO finished_jobs SELECT * FROM que_jobs WHERE queue = $1::text AND priority = $2::integer AND run_at = $3::timestamptz AND job_id = $4::bigint", @attrs.values_at(:queue, :priority, :run_at, :job_id)
+        Que.execute "INSERT INTO finished_jobs SELECT * FROM que_jobs WHERE queue = $1::text AND priority = $2::integer AND run_at = $3::timestamp AND job_id = $4::bigint", @attrs.values_at(:queue, :priority, :run_at, :job_id)
         super
       end
     end

--- a/lib/que/adapters/base.rb
+++ b/lib/que/adapters/base.rb
@@ -109,6 +109,14 @@ module Que
       # Timestamp with time zone.
       CAST_PROCS[1184] = Time.method(:parse)
 
+      # Timestamp without time zone.
+      CAST_PROCS[1114] = ->(time_string) do
+        d = Date._parse(time_string)
+        Time.send :make_time, d[:year], d[:mon], d[:mday], d[:hour],
+                              d[:min],  d[:sec], d[:sec_fraction],
+                              'UTC', Time.now.utc
+      end
+
       # JSON.
       CAST_PROCS[114] = JSON_MODULE.method(:load)
 

--- a/lib/que/job.rb
+++ b/lib/que/job.rb
@@ -43,7 +43,7 @@ module Que
         warn "@default_run_at in #{to_s} has been deprecated and will be removed in Que version 1.0.0. Please use @run_at instead." if @default_run_at
 
         if t = run_at || @run_at && @run_at.call || @default_run_at && @default_run_at.call
-          attrs[:run_at] = t
+          attrs[:run_at] = t.utc
         end
 
         warn "@default_priority in #{to_s} has been deprecated and will be removed in Que version 1.0.0. Please use @priority instead." if @default_priority

--- a/lib/que/migrations/1/up.sql
+++ b/lib/que/migrations/1/up.sql
@@ -1,7 +1,7 @@
 CREATE TABLE que_jobs
 (
   priority    integer     NOT NULL DEFAULT 1,
-  run_at      timestamptz NOT NULL DEFAULT now(),
+  run_at      timestamp   NOT NULL DEFAULT timezone('UTC'::text, now()),
   job_id      bigserial   NOT NULL,
   job_class   text        NOT NULL,
   args        json        NOT NULL DEFAULT '[]'::json,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -41,6 +41,7 @@ QUE_ADAPTERS = {:pg => Que.adapter}
 
 # We use Sequel to examine the database in specs.
 require 'sequel'
+Sequel.default_timezone = :utc
 DB = Sequel.connect(QUE_URL)
 
 

--- a/spec/unit/customization_spec.rb
+++ b/spec/unit/customization_spec.rb
@@ -99,7 +99,7 @@ describe "Customizing Que" do
     it "with a Ruby override" do
       class MyJobClass < Que::Job
         def destroy
-          Que.execute "INSERT INTO finished_jobs SELECT * FROM que_jobs WHERE queue = $1::text AND priority = $2::integer AND run_at = $3::timestamptz AND job_id = $4::bigint", @attrs.values_at(:queue, :priority, :run_at, :job_id)
+          Que.execute "INSERT INTO finished_jobs SELECT * FROM que_jobs WHERE queue = $1::text AND priority = $2::integer AND run_at = $3::timestamp AND job_id = $4::bigint", @attrs.values_at(:queue, :priority, :run_at, :job_id)
           super
         end
       end


### PR DESCRIPTION
Using timestamp with timezone is not unified, as an ActiveRecord storing `updated_at` or `created_at` as an timestamp without timezone, let's Que do something like this
