### PR TITLE
Added transaction verbosity for activerecord

### DIFF
--- a/spec/adapters/active_record_spec.rb
+++ b/spec/adapters/active_record_spec.rb
@@ -4,7 +4,11 @@ unless defined?(RUBY_ENGINE) && RUBY_ENGINE == 'jruby'
   require 'spec_helper'
   require 'active_record'
 
+  if ActiveRecord.version.release >= Gem::Version.new('4.2')
+    ActiveRecord::Base.raise_in_transactional_callbacks = true
+  end
   ActiveRecord::Base.establish_connection(QUE_URL)
+
   Que.connection = ActiveRecord
   QUE_ADAPTERS[:active_record] = Que.adapter
 


### PR DESCRIPTION
Make spec from c1f32f6 fail

As you can see here https://github.com/rails/rails/blob/master/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb#L75

AR by default swallows exception. But in rails app, this attribute set to true.
After you merge this request, you will find #64 very helpful
