### PR TITLE
Add "Web UI" to inspecting the queue

### DIFF
--- a/docs/inspecting_the_queue.md
+++ b/docs/inspecting_the_queue.md
@@ -98,3 +98,17 @@ And note that Sequel *does* support composite primary keys:
 Or, you can just use Sequel's dataset methods:
 
     DB[:que_jobs].where{priority > 3}.all
+
+### Web UI
+
+[que-web](https://github.com/statianzo/que-web) is a web interface for inspecting queues. Map it inside your `config.ru`
+
+    require "que/web"
+    map "/que" do
+      run Que::Web
+    end
+    
+or in your Rails `config/routes.rb`
+
+    require "que/web"
+    mount Que::Web => "/que"


### PR DESCRIPTION
I put together a [gem](https://github.com/statianzo/que-web) for a web interface to Que. Currently, it will give you a breakdown of running, scheduled, and failing jobs. Deleting and scheduling immediately works. It also gives you visibility into the `last_error` stack traces.

![failing](https://cloud.githubusercontent.com/assets/57737/5074633/8121289c-6e49-11e4-9e6b-0e1ef0125249.png)
![job](https://cloud.githubusercontent.com/assets/57737/5074635/8121bcb2-6e49-11e4-9a6f-816c3e40a7b4.png)
![scheduled](https://cloud.githubusercontent.com/assets/57737/5074634/8121f5a6-6e49-11e4-89ff-d7f525874590.png)
