### PR TITLE
Add que-testing related gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ If you're using ActiveRecord to dump your database's schema, you'll probably wan
 ## Related Gems
 
   * [que-web](https://github.com/statianzo/que-web) is a Sinatra-based UI for inspecting your job queue.
+  * [que-testing](https://github.com/statianzo/que-testing) allows making assertions on enqueued jobs.
 
 If you have a gem that uses or relates to Que, feel free to submit a PR adding it to the list!
 


### PR DESCRIPTION
que-testing allows you to enqueue jobs without a database or synchronous running. It allows you to make assertions such as `MyJob.jobs.length.must_equal 2` during tests.
