### PR TITLE
Provide failing job in error_handler

### DIFF
--- a/lib/que/job.rb
+++ b/lib/que/job.rb
@@ -118,7 +118,7 @@ module Que
 
             if Que.error_handler
               # Similarly, protect the work loop from a failure of the error handler.
-              Que.error_handler.call(error) rescue nil
+              Que.error_handler.call(error, job) rescue nil
             end
 
             return {:event => :job_errored, :error => error, :job => job}

--- a/spec/unit/work_spec.rb
+++ b/spec/unit/work_spec.rb
@@ -323,6 +323,22 @@ describe Que::Job, '.work' do
       end
     end
 
+    it "should pass job to an error handler, if one is defined" do
+      begin
+        jobs = []
+        Que.error_handler = proc { |error, job| jobs << job }
+
+        ErrorJob.enqueue
+        result = Que::Job.work
+
+        jobs.count.should be 1
+        job = jobs[0]
+        job.should be result[:job]
+      ensure
+        Que.error_handler = nil
+      end
+    end
+
     it "should not do anything if the error handler itelf throws an error" do
       begin
         Que.error_handler = proc { |error| raise "Another error!" }


### PR DESCRIPTION
Knowing the job allows the handler to take specific actions based upon
the specific job that failed. For example, dequeuing if the error count
is past a certain threshold.
My use case is wanting to push job name and arguments up to [Rollbar](https://rollbar.com) when jobs fail.

This change potentially breaking if the assigned error handler has a 
strict arity (using a lambda instead of a proc). I can adjust the PR to
check arity if that's a concern.
