### PR TITLE
Locking algorithm somewhat more resistant to long-lived transactions

### DIFF
--- a/lib/que/job.rb
+++ b/lib/que/job.rb
@@ -75,14 +75,14 @@ module Que
         new(:args => args).tap { |job| job.run(*args) }
       end
 
-      def work(queue = '')
+      def work(queue = '', min_job_id = 0)
         # Since we're taking session-level advisory locks, we have to hold the
         # same connection throughout the process of getting a job, working it,
         # deleting it, and removing the lock.
         return_value =
           Que.adapter.checkout do
             begin
-              if job = Que.execute(:lock_job, [queue]).first
+              if job = Que.execute(:lock_job, [queue, min_job_id]).first
                 # Edge case: It's possible for the lock_job query to have
                 # grabbed a job that's already been worked, if it took its MVCC
                 # snapshot while the job was processing, but didn't attempt the

--- a/lib/que/sql.rb
+++ b/lib/que/sql.rb
@@ -48,6 +48,7 @@ module Que
           FROM que_jobs AS j
           WHERE queue = $1::text
           AND run_at <= now()
+          AND job_id > $2::bigint
           ORDER BY priority, run_at, job_id
           LIMIT 1
         ) AS t1

--- a/lib/que/worker.rb
+++ b/lib/que/worker.rb
@@ -62,7 +62,8 @@ module Que
     # that it allows any jobs with IDs lower than any current worker is
     # handling to be discovered and locked (that may happen in the case of a
     # crashed worker or an out-of-order transaction commit).
-    HARD_LOCK_INTERVAL = 10
+    HARD_LOCK_INTERVAL =
+      ENV["QUE_HARD_LOCK_INTERVAL"] ? ENV["QUE_HARD_LOCK_INTERVAL"].to_i : 10
 
     # Sleep very briefly while waiting for a thread to get somewhere.
     def wait


### PR DESCRIPTION
Hey @chanks! I meant to try and send this in months ago, but never got around to it, so I wanted to loop back around and get your thoughts. This is my personal branch that's slightly more tolerant to long-lived transactions in a database as I think that you probably already remember from [an article and discussion on HN not too long ago](https://brandur.org/postgres-queues).

Possible considerations here:
- The branch works, but isn't perfect. Long-lived transactions will still take it down.
- This stuff is pretty hard to test, so I haven't included coverage of any substance here. (Let me know if you have any ideas on how to improve this.)
- There is some increase to code complexity and it may be surprising to people reading the codebase.

Let me know if you have any other thoughts/ideas here. Thanks!

/cc @mikehale
