### PR TITLE
Mention Active Job integration in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,24 +126,22 @@ usage: que [options] [file/to/require] ...
 
 You may need to pass que a file path to require so that it can load your app. Que will automatically load `config/environment.rb` if it exists, so you shouldn't need an argument if you're using Rails.
 
-## Usage with Active Job
+## Additional Rails-specific Setup
 
-If you would rather integrate Que with Active Job, you can do it by setting the adapter in `config/application.rb` or in a specific environment by setting it in `config/environments/production.rb`, for example:
+If you're using ActiveRecord to dump your database's schema, please [set your schema_format to :sql](http://guides.rubyonrails.org/migrations.html#types-of-schema-dumps) so that Que's table structure is managed correctly. This is a good idea regardless, as the `:ruby` schema format doesn't support many of PostgreSQL's advanced features.
+
+Pre-1.0, the default queue name needed to be configured in order for Que to work out of the box with Rails. In 1.0 the default queue name is now 'default', as Rails expects, but when Rails enqueues some types of jobs it may try to use another queue name that isn't worked by default - in particular, ActionMailer uses a queue named 'mailers' by default, so in your app config you'll also need to set `config.action_mailer.deliver_later_queue_name = 'default'` if you're using ActionMailer.
+
+Also, if you would like to integrate Que with Active Job, you can do it by setting the adapter in `config/application.rb` or in a specific environment by setting it in `config/environments/production.rb`, for example:
 ```ruby
 config.active_job.queue_adapter = :que
 ```
 
 Que will automatically pick up the database from Active Record, so there is no need to configure anything else.
 
-You can then write your jobs as usual following the [Active Job documentation](https://guides.rubyonrails.org/active_job_basics.html). However be aware that you'll lose the ability to finish the job in the same transaction as other database operations. That happens because Active Job is a generic background job framework that doesn't benefit of the database integration Que provides.
+You can then write your jobs as usual following the [Active Job documentation](https://guides.rubyonrails.org/active_job_basics.html). However, be aware that you'll lose the ability to finish the job in the same transaction as other database operations. That happens because Active Job is a generic background job framework that doesn't benefit from the database integration Que provides.
 
 If you later decide to switch a job from Active Job to Que to have transactional integrity you can easily change the corresponding job class to inherit from `Que::Job` and follow the usage guidelines in the previous section.
-
-## Additional Rails-specific Setup
-
-If you're using ActiveRecord to dump your database's schema, please [set your schema_format to :sql](http://guides.rubyonrails.org/migrations.html#types-of-schema-dumps) so that Que's table structure is managed correctly. This is a good idea regardless, as the `:ruby` schema format doesn't support many of PostgreSQL's advanced features.
-
-Pre-1.0, the default queue name needed to be configured in order for Que to work out of the box with Rails. In 1.0 the default queue name is now 'default', as Rails expects, but when Rails enqueues some types of jobs it may try to use another queue name that isn't worked by default - in particular, ActionMailer uses a queue named 'mailers' by default, so in your app config you'll also need to set `config.action_mailer.deliver_later_queue_name = 'default'` if you're using ActionMailer.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ You may need to pass que a file path to require so that it can load your app. Qu
 
 If you would rather integrate Que with Active Job, you can do it by setting the adapter in `config/application.rb` or in a specific environment by setting it in `config/environments/production.rb`, for example:
 ```ruby
-ActiveJob::Base.queue_adapter = :que
+config.active_job.queue_adapter = :que
 ```
 
 Que will automatically pick up the database from Active Record, so there is no need to configure anything else.

--- a/README.md
+++ b/README.md
@@ -126,6 +126,19 @@ usage: que [options] [file/to/require] ...
 
 You may need to pass que a file path to require so that it can load your app. Que will automatically load `config/environment.rb` if it exists, so you shouldn't need an argument if you're using Rails.
 
+## Usage with Active Job
+
+If you would rather integrate Que with Active Job, you can do it by setting the adapter in `config/application.rb` or in a specific environment by setting it in `config/environments/production.rb`, for example:
+```ruby
+ActiveJob::Base.queue_adapter = :que
+```
+
+Que will automatically pick up the database from Active Record, so there is no need to configure anything else.
+
+You can then write your jobs as usual following the [Active Job documentation](https://guides.rubyonrails.org/active_job_basics.html). However be aware that you'll lose the ability to finish the job in the same transaction as other database operations. That happens because Active Job is a generic background job framework that doesn't benefit of the database integration Que provides.
+
+If you later decide to switch a job from Active Job to Que to have transactional integrity you can easily change the corresponding job class to inherit from `Que::Job` and follow the usage guidelines in the previous section.
+
 ## Additional Rails-specific Setup
 
 If you're using ActiveRecord to dump your database's schema, please [set your schema_format to :sql](http://guides.rubyonrails.org/migrations.html#types-of-schema-dumps) so that Que's table structure is managed correctly. This is a good idea regardless, as the `:ruby` schema format doesn't support many of PostgreSQL's advanced features.

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Also, if you would like to integrate Que with Active Job, you can do it by setti
 config.active_job.queue_adapter = :que
 ```
 
-Que will automatically pick up the database from Active Record, so there is no need to configure anything else.
+Que will automatically use the database configuration of your rails application, so there is no need to configure anything else.
 
 You can then write your jobs as usual following the [Active Job documentation](https://guides.rubyonrails.org/active_job_basics.html). However, be aware that you'll lose the ability to finish the job in the same transaction as other database operations. That happens because Active Job is a generic background job framework that doesn't benefit from the database integration Que provides.
 


### PR DESCRIPTION
Thank you for this great library!

I've read the discussion on #127 and it seems like now there is great Active Job integration, so maybe it would be nice to document it so that new users can easily find it and decide to use it.

It took me a while to find this library because it is not mentioned in the [Rails Guides](https://guides.rubyonrails.org/active_job_basics.html#starting-the-backend), even though it is mentioned in the [API docs](https://api.rubyonrails.org/classes/ActiveJob/QueueAdapters.html). It seems like the guides are more beginner-friendly and have links specific to the README section explaining how to integrate the library with Active Job. Hence if we have that section in the README we could have a link from Rails Guides pointing directly to it which would bring people here.

What do you think?