### PR TITLE
Sequel niceties

### DIFF
--- a/lib/que/sequel/model.rb
+++ b/lib/que/sequel/model.rb
@@ -18,8 +18,8 @@ module Que
           subset :"not_#{name}", ~condition
         end
 
-        subset :ready,     conditions.values.map(&:~).inject{|a, b| a & b}
-        subset :not_ready, conditions.values.         inject{|a, b| a | b}
+        subset :ready,     conditions.values.map(&:~).inject(:&)
+        subset :not_ready, conditions.values.         inject(:|)
 
         def by_job_class(job_class)
           job_class = job_class.name if job_class.is_a?(Class)

--- a/lib/que/sequel/model.rb
+++ b/lib/que/sequel/model.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+::Sequel.extension :pg_json_ops
+
 module Que
   module Sequel
     QUALIFIED_TABLE = ::Sequel.qualify(:public, :que_jobs)
@@ -26,7 +28,7 @@ module Que
           where(
             (QUALIFIED_TABLE[:job_class] =~ job_class) |
               (QUALIFIED_TABLE[:job_class] =~ "ActiveJob::QueueAdapters::QueAdapter::JobWrapper") &
-              ::Sequel[::Sequel.lit("public.que_jobs.args->0->>'job_class'") => job_class]
+              (QUALIFIED_TABLE[:args].pg_jsonb[0].get_text(job_class))
           )
         end
 
@@ -35,11 +37,11 @@ module Que
         end
 
         def by_tag(tag)
-          where(::Sequel.lit("public.que_jobs.data @> ?", JSON.dump(tags: [tag])))
+          where(QUALIFIED_TABLE[:data].pg_jsonb.contains(tags: [tag]))
         end
 
         def by_args(*args)
-          where(::Sequel.lit("public.que_jobs.args @> ?", JSON.dump(args)))
+          where(QUALIFIED_TABLE[:args].pg_jsonb.contains(args))
         end
       end
     end


### PR DESCRIPTION
*Re-opening https://github.com/chanks/que/pull/250 here.*

I noticed the Sequel adapter can be simplified a bit, so I went ahead and did it. There are several types of changes here:

* use `[]` instead of `Sequel.qualify`
* use `!~` instead of `Sequel.~(a => b)`
* use combination of `|`, `&` and `=~` operators instead of `Sequel.|`
* use `pg_json_ops` Sequel extension for building JSONB expressions
* pass an operator symbol to `#inject`

I feel like this made the code more consistent and easier to read. Note that all these changes are purely cosmetic, the behaviour should stay unchanged.