### PR TITLE
Sequel niceties

### DIFF
--- a/lib/que/sequel/model.rb
+++ b/lib/que/sequel/model.rb
@@ -18,8 +18,8 @@ module Que
           subset :"not_#{name}", ~condition
         end
 
-        subset :ready,     conditions.values.map(&:~).inject{|a, b| a & b}
-        subset :not_ready, conditions.values.         inject{|a, b| a | b}
+        subset :ready,     conditions.values.map(&:~).inject(:&)
+        subset :not_ready, conditions.values.         inject(:|)
 
         def by_job_class(job_class)
           job_class = job_class.name if job_class.is_a?(Class)


### PR DESCRIPTION
PR by @janko

---

I noticed the Sequel adapter can be simplified a bit, so I went ahead and did it. There are several types of changes here:

* use `[]` instead of `Sequel.qualify`
* use `!~` instead of `Sequel.~(a => b)`
* use combination of `|`, `&` and `=~` operators instead of `Sequel.|`
* use `pg_json_ops` Sequel extension for building JSONB expressions
* pass an operator symbol to `#inject`

I feel like this made the code more consistent and easier to read. Note that all these changes are purely cosmetic, the behaviour should stay unchanged.

Reopening #250 