### PR TITLE
Update que-scheduler as 0.x and 1.x compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ There are a couple ways to do testing. You may want to set `Que::Job.run_synchro
 These projects are tested to be compatible with Que 1.x:
 
 - [que-web](https://github.com/statianzo/que-web) is a Sinatra-based UI for inspecting your job queue.
-- [que-scheduler](https://github.com/hlascelles/que-scheduler) lets you schedule tasks using a cron style config file. (que-1.0-compatibility branch required).
+- [que-scheduler](https://github.com/hlascelles/que-scheduler) lets you schedule tasks using a cron style config file.
 
 If you have a project that uses or relates to Que, feel free to submit a PR adding it to the list!
 


### PR DESCRIPTION
que-scheduler is now compatible with both 0.x and 1.x branches of que.