### PR TITLE
Add link to que-locks for exclusive job locking

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ These projects are tested to be compatible with Que 1.x:
 
 - [que-web](https://github.com/statianzo/que-web) is a Sinatra-based UI for inspecting your job queue.
 - [que-scheduler](https://github.com/hlascelles/que-scheduler) lets you schedule tasks using a cron style config file.
+- [que-locks](https://github.com/airhorns/que-locks) lets you lock around job execution for so only one job runs at once for a set of arguments.
 
 If you have a project that uses or relates to Que, feel free to submit a PR adding it to the list!
 


### PR DESCRIPTION
I've been using https://github.com/airhorns/que-locks for some basic exclusive locking around job execution in my (admittedly pretty small) production app using `que` for a couple months now. Saw que fly by on HN the other day and figured it might be good to open source the locking code and share it, so I published that over there.

From the que-locks readme:

> `que-locks` adds an opt-in feature to `Que::Jobs` allowing jobs to specify that exactly one instance of a job should be executing at once. This is useful for jobs that are doing something important that should only ever happen one at a time, like processing a payment for a given user, or super expensive jobs that could cause thundering herd problems if enqueued all at the same time.

This adds a link to the readme so folks can at least find `que-locks`, but it's worth noting that I've been the only user and not at crazy scale, so it might not meet the standard of what should be linked to in the readme. I don't mind waiting for some more users or something like that before adding this, but I figured I'd open the PR to see what the community thinks!

