### PR TITLE
Set schema in table_name for ActiveRecord model

### DIFF
--- a/lib/que/active_record/model.rb
+++ b/lib/que/active_record/model.rb
@@ -3,7 +3,7 @@
 module Que
   module ActiveRecord
     class Model < ::ActiveRecord::Base
-      self.table_name = :que_jobs
+      self.table_name = 'public.que_jobs'
 
       t = arel_table
 


### PR DESCRIPTION
As long as `que_jobs` is put into `public` namespace by purpose, it would be good to explicitly set it in ActiveRecord model. Otherwise application with changed `search_path` is not able to access `que_jobs`.