### PR TITLE
Fix CI failure from Docker Postgres image

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -13,6 +13,8 @@ jobs:
     services:
       db:
         image: postgres:${{ matrix.postgres_version }}
+        env:
+          POSTGRES_HOST_AUTH_METHOD: trust
         ports: ['5432:5432']
         options: >-
           --health-cmd pg_isready


### PR DESCRIPTION
The failure is caused by a change to the Docker Postgres base image.  Using an empty string for the database password (the default value) now causes initialization to fail, unless a specific environment variable is set.

See docker-library/postgres#681 for more information.
