### PR TITLE
Test with Ruby 2.7

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -7,9 +7,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby_version: [2.5.x, 2.6.x]
+        ruby_version: [2.5.x, 2.6.x, 2.7.x]
         gemfile: ["4.2", "5.2", "6.0"]
         postgres_version: [9, 10, 11]
+        exclude:
+          - { gemfile: "4.2", ruby_version: "2.7.x" }
     services:
       db:
         image: postgres:${{ matrix.postgres_version }}


### PR DESCRIPTION
Rails 4.2 is excluded when testing with Ruby 2.7 because Ruby 2.7 breaks some Rails 4.2 internal code.  Note that Rails 4.2 is end-of-life, so these breakages won't be fixed.