### PR TITLE
Run GitHub build workflow on push

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,6 +1,6 @@
 name: Ruby
 
-on: [pull_request]
+on: [push, pull_request]
 
 jobs:
   test:


### PR DESCRIPTION
This helps to identify any commit pushed directly to master that breaks the build.  It would also catch a hypothetical bad merge commit that breaks the build.

This also makes it easier for contributors to iteratively test their changes on their fork before making a pull request.
