### PR TITLE
Add instructions for how to start Que

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,14 @@ You can also add options to run the job after a specific time, or with a specifi
 ``` ruby
 ChargeCreditCard.enqueue card.id, user_id: current_user.id, run_at: 1.day.from_now, priority: 5
 ```
+## Running the Que Worker
+In order to process jobs, you must start a separate worker process outside of your main server. 
 
-Finally, you can work jobs using the included `que` CLI. Try running `que -h` to get a list of runtime options:
+```
+bundle exec que
+```
+
+Try running `que -h` to get a list of runtime options:
 ```
 $ que -h
 usage: que [options] [file/to/require] ...


### PR DESCRIPTION
While this is fairly self explanatory, it took me a sec to investigate and confirm this is the proper usage. This update makes the `bundle exec que` usage clear and will make this much more beginner friendly.