### PR TITLE
Add more context to error message when config files fail to load.

### DIFF
--- a/bin/command_line_interface.rb
+++ b/bin/command_line_interface.rb
@@ -183,8 +183,8 @@ OUTPUT
         args.each do |file|
           begin
             require file
-          rescue LoadError
-            output.puts "Could not load file '#{file}'"
+          rescue LoadError => e
+            output.puts "Could not load file '#{file}': #{e}"
             return 1
           end
         end

--- a/bin/command_line_interface.spec.rb
+++ b/bin/command_line_interface.spec.rb
@@ -168,7 +168,7 @@ MSG
       code = execute "./#{name} ./nonexistent_file"
       assert_equal 1, code
 
-      assert_equal ["Could not load file './nonexistent_file'"], output.messages
+      assert_equal ["Could not load file './nonexistent_file': cannot load such file -- ./nonexistent_file"], output.messages
 
       assert_equal(
         {name => true},


### PR DESCRIPTION
Currently when a configuration/app file is required, if it fails for any reason, then a simple "Could not load file" message is given.

This might be because the required file is missing, or it could be because it contains errors.

This commit adds more context to the reason for the failure, helping debug cases where the required file contains an error.