### PR TITLE
Fix lock leak on PostgreSQL 12 and later

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         ruby_version: [2.5.x, 2.6.x, 2.7.x]
         gemfile: ["4.2", "5.2", "6.0"]
-        postgres_version: [9, 10, 11]
+        postgres_version: [9, 10, 11, 12]
         exclude:
           - { gemfile: "4.2", ruby_version: "2.7.x" }
     services:

--- a/lib/que/connection.rb
+++ b/lib/que/connection.rb
@@ -119,6 +119,10 @@ module Que
       loop { break if next_notification.nil? }
     end
 
+    def server_version
+      wrapped_connection.server_version
+    end
+
     def in_transaction?
       wrapped_connection.transaction_status != ::PG::PQTRANS_IDLE
     end

--- a/lib/que/connection.spec.rb
+++ b/lib/que/connection.spec.rb
@@ -45,6 +45,14 @@ describe Que::Connection do
         end
       end
 
+      describe "server_version" do
+        it "returns the PostgreSQL server version" do
+          assert_instance_of Integer, connection.server_version
+          assert_operator connection.server_version, :>=, 9_06_00
+          assert_operator connection.server_version, :<, 99_00_00
+        end
+      end
+
       describe "in_transaction?" do
         it "should know when it is in a transaction" do
           refute connection.in_transaction?

--- a/lib/que/locker.rb
+++ b/lib/que/locker.rb
@@ -393,10 +393,12 @@ module Que
         }
       end
 
+      materalize_cte = connection.server_version >= 12_00_00
+
       jobs =
         connection.execute \
           <<-SQL
-            WITH jobs AS (SELECT * FROM que_jobs WHERE id IN (#{ids.join(', ')}))
+            WITH jobs AS #{materalize_cte ? 'MATERIALIZED' : ''} (SELECT * FROM que_jobs WHERE id IN (#{ids.join(', ')}))
             SELECT * FROM jobs WHERE pg_try_advisory_lock(id)
           SQL
 

--- a/lib/que/migrations.spec.rb
+++ b/lib/que/migrations.spec.rb
@@ -9,7 +9,7 @@ describe Que::Migrations do
 
     default = proc do
       result = Que.execute <<-SQL
-        select adsrc::integer
+        select pg_get_expr(adbin, adrelid)::integer AS adsrc
         from pg_attribute a
         join pg_class c on c.oid = a.attrelid
         join pg_attrdef on adrelid = attrelid AND adnum = attnum


### PR DESCRIPTION
Fixes #290.

PostgreSQL 12 and later do not materialise all CTEs automatically. This can result in multiple scans occurring which in turn can result in `pg_try_advisory_lock` being invoked multiple times on the same job. This results in a leak as we only call unlock once. This PR forces the CTE in the locker to be materialised which matches pre-PostgreSQL 12 behaviour.

I wasn’t able to reproduce any similar issues with the polling code but it’s possible the same issue exists there. I suspect the `lock_taken` CTE being used twice in `lock_and_update_priorities` is enough to trigger the materialisation path there.

This PR also fixes the use of an obsolete column in `pg_attrdef` which was preventing a green build on PostgreSQL 12.