### PR TITLE
Fixes for Ruby 3.0 compatibility

### DIFF
--- a/bin/command_line_interface.rb
+++ b/bin/command_line_interface.rb
@@ -221,7 +221,7 @@ OUTPUT
 
         locker =
           begin
-            Que::Locker.new(options)
+            Que::Locker.new(**options)
           rescue => e
             output.puts(e.message)
             return 1

--- a/lib/que/worker.rb
+++ b/lib/que/worker.rb
@@ -118,7 +118,7 @@ module Que
           log_message[:event] = :job_worked
         end
 
-        Que.log(log_message)
+        Que.log(**log_message)
       end
 
       instance


### PR DESCRIPTION
Not sure whether there are other places, but these were enough to get Que running in our setup.

Afaik the double-splat operator should be compatible with all Ruby versions >= 2.0.