### PR TITLE
Prevent race condition when JobBuffer#push is run in a tight loop and workers are waiting on jobs

### DIFF
--- a/lib/que/job_buffer.rb
+++ b/lib/que/job_buffer.rb
@@ -59,10 +59,8 @@ module Que
 
         # Relying on the hash's contents being sorted, here.
         priority_queues.reverse_each do |_, pq|
-          pq.waiting_count.times do
-            job = _shift_job(pq.priority)
-            break if job.nil? # False would mean we're stopping.
-            pq.push(job)
+          pq.populate do
+            _shift_job(pq.priority)
           end
         end
 
@@ -226,18 +224,20 @@ module Que
         end
       end
 
-      def push(item)
-        sync do
-          Que.assert(waiting_count > 0)
-          @items << item
-          @cv.signal
-        end
-      end
-
       def stop
         sync do
           @stopping = true
           @cv.broadcast
+        end
+      end
+
+      def populate
+        sync do
+          waiting_count.times do
+            job = yield
+            break if job.nil? # False would mean we're stopping.
+            _push(job)
+          end
         end
       end
 
@@ -249,6 +249,12 @@ module Que
 
       def sync(&block)
         mutex.synchronize(&block)
+      end
+
+      def _push(item)
+        Que.assert(waiting_count > 0)
+        @items << item
+        @cv.signal
       end
     end
   end


### PR DESCRIPTION
This PR resolves an issue identified by @ebeigarts while crafting a test for #285 (see [comment](https://github.com/que-rb/que/pull/285#issuecomment-640566777)).

NOTE: this PR depends on #285, but we thought we would merge that PR separately rather than attempting to mash these changes in too.

### Problem
The crux of the issue is that when `JobBuffer#push` is run on a tight loop (as it is in the test provided by @ebeigarts, which we have committed here, with credit) while there are workers waiting on jobs, there is a race condition between:
1. a worker being released in `PriorityQueue#pop` and reducing the `@waiting` counter
2. the thread running `JobBuffer#push` re-entering that method and evaluating `pq.waiting_count.times`

If 2 happens before 1 (which seems unlikely but not impossible), then then too many jobs will be pushed into the priority queue, leading to the `Que.assert(waiting_count > 0)` assertion in `ProrityQueue#push` failing.

It's unclear whether this is all that likely to happen in reality, but given there is proof that the race condition is possible we thought it better to try and resolve it.

### Resolution
By shifting the push loop into the priority worker itself (`#populate`), we are able to utilize the priority queue's own mutex to ensure the `@waiting` count does not change while the push loop is running.

We have made `PriorityQueue#_push` a private unsynchonized method since it is now only used via `#populate`.

It's unclear whether there are performance impacts from making this change (workers are blocked from picking up jobs which we are pushing new jobs into each queue), but there is no measurable difference in the time taken for the test (about 2.3s with the original version which moves 40k jobs through the buffer) on my machine with or without this change.


