### PR TITLE
Fix worker thread attrition

### DIFF
--- a/lib/que/job_buffer.spec.rb
+++ b/lib/que/job_buffer.spec.rb
@@ -209,8 +209,8 @@ describe Que::JobBuffer do
     it "should not deadlock" do
       job_buffer # Pre-initialize to avoid race conditions.
 
-      concurrency = 2
-      jobs_count_per_thread = 500
+      concurrency = 4
+      jobs_count_per_thread = 10_000
 
       push_thread = Thread.new do
         (concurrency * jobs_count_per_thread).times do

--- a/lib/que/job_buffer.spec.rb
+++ b/lib/que/job_buffer.spec.rb
@@ -8,11 +8,12 @@ describe Que::JobBuffer do
 
   let :job_buffer do
     Que::JobBuffer.new(
-      maximum_size: 8,
+      maximum_size: maximum_size,
       minimum_size: 0,
       priorities: [10, 30, 50, nil].shuffle,
     )
   end
+  let(:maximum_size) { 8 }
 
   let :job_array do
     [
@@ -202,11 +203,14 @@ describe Que::JobBuffer do
   end
 
   describe "push and shift" do
+    # Prevent dropping excess jobs
+    let(:maximum_size) { 100_000 }
+
     it "should not deadlock" do
       job_buffer # Pre-initialize to avoid race conditions.
 
-      concurrency = 4
-      jobs_count_per_thread = 10_000
+      concurrency = 2
+      jobs_count_per_thread = 500
 
       push_thread = Thread.new do
         (concurrency * jobs_count_per_thread).times do
@@ -223,21 +227,16 @@ describe Que::JobBuffer do
       end
 
       deadlock_detected = false
-      unlock_thread = Thread.new do
-        sleep 10
-
+      deadlock_detector_thread = Thread.new do
+        sleep 5
         deadlock_detected = true
         push_thread.kill
-        shift_threads.each { |t| t.kill }
+        shift_threads.each(&:kill)
       end
 
       push_thread.join
-      (concurrency * jobs_count_per_thread).times do
-        job_buffer.push(*job_array[0])
-      end
-
-      shift_threads.each { |t| t.join }
-      unlock_thread.kill
+      shift_threads.each(&:join)
+      deadlock_detector_thread.kill
 
       if deadlock_detected
         raise "Deadlock"


### PR DESCRIPTION
The changes in https://github.com/que-rb/que/pull/285 unfortunately introduced a race condition bug where the result from `Worker#fetch_next_metajob` (which just calls `JobBuffer#shift`) could be unexpectedly nil, and so the truthiness check in the `Worker#work_loop`'s while loop could evaluate to false, causing the worker thread to stop. For details, see https://github.com/que-rb/que/pull/285#issuecomment-989319178.

We've fixed this by handling nil separately from false, and in that case, restarting the loop to do the fetch again, which should return a proper result the next time. We realise it's not the cleanest of fixes, but we'd prefer to get the fix in, and refactor later if the need arises.

The test this adds covers the changes from: here, https://github.com/que-rb/que/pull/285, and https://github.com/que-rb/que/pull/318. It's a fixed version of the test submitted in a comment by @ebeigarts: https://github.com/que-rb/que/pull/285#issuecomment-640566777