### PR TITLE
Add Docker for easier setup of Que development environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM ruby:2.7.5-slim-buster@sha256:4cbbe2fba099026b243200aa8663f56476950cc64ccd91d7aaccddca31e445b5 AS base
+
+# Install libpq-dev in our base layer, as it's needed in all environments
+RUN apt-get update \
+  && apt-get install -y libpq-dev \
+  && rm -rf /var/lib/apt/lists/*
+
+ENV RUBY_BUNDLER_VERSION 2.3.1
+RUN gem install bundler -v $RUBY_BUNDLER_VERSION
+
+ENV BUNDLE_PATH /usr/local/bundle
+
+ENV RUBYOPT=-W:deprecated
+
+FROM base AS dev-environment
+
+# Install build-essential and git, as we'd need them for building gems that have native code components
+RUN apt-get update \
+  && apt-get install -y build-essential git \
+  && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update \
   && apt-get install -y libpq-dev \
   && rm -rf /var/lib/apt/lists/*
 
-ENV RUBY_BUNDLER_VERSION 2.3.1
+ENV RUBY_BUNDLER_VERSION 2.3.7
 RUN gem install bundler -v $RUBY_BUNDLER_VERSION
 
 ENV BUNDLE_PATH /usr/local/bundle

--- a/README.md
+++ b/README.md
@@ -191,10 +191,6 @@ Regarding contributions, one of the project's priorities is to keep Que as simpl
 
 ### Specs
 
-To run the specs using Docker (avoiding manual setup), use:
-
-    ./auto/test
-
 A note on running specs - Que's worker system is multithreaded and therefore prone to race conditions. As such, if you've touched that code, a single spec run passing isn't a guarantee that any changes you've made haven't introduced bugs. One thing I like to do before pushing changes is rerun the specs many times and watching for hangs. You can do this from the command line with something like:
 
     for i in {1..1000}; do SEED=$i bundle exec rake; done
@@ -206,3 +202,23 @@ This will iterate the specs one thousand times, each with a different ordering. 
 Note that we iterate because there's no guarantee that the hang would reappear with a single additional run, so we need to rerun the specs until it reappears. The LOG_SPEC parameter will output the name and file location of each spec before it is run, so you can easily tell which spec is hanging, and you can continue narrowing things down from there.
 
 Another helpful technique is to replace an `it` spec declaration with `hit` - this will run that particular spec 100 times during the run.
+
+#### **With docker-compose**
+To run the specs using Docker/`docker-compose` (avoiding manual setup), use:
+
+    ./auto/test
+The `docker-compose` file provides a convenience method for injecting your local shell aliases into the Docker container. Simply drop a file containing your alias definitions into `~/.docker-rc.d/`, and they will be available inside the container. This is helpful if you're doing interactive running/debugging with `auto/dev`.
+
+#### **Without docker-compose**
+
+You'll need to have Postgres running locally.
+Assuming you have a local Postgres database set up with username and password `que`, you can run
+
+```
+DATABASE_URL=postgres://que:que@localhost/que bundle exec rake spec
+```
+
+If for some reason you have Docker installed without `docker-compose`, a quick way to set up said database is to spin up a Docker image of your preferred Postgres version, e.g.
+```
+docker run -e POSTGRES_PASSWORD=que -e POSTGRES_USER=que -p 5432:5432 -d postgres:11.0
+```

--- a/README.md
+++ b/README.md
@@ -191,6 +191,10 @@ Regarding contributions, one of the project's priorities is to keep Que as simpl
 
 ### Specs
 
+To run the specs using Docker (avoiding manual setup), use:
+
+    ./auto/test
+
 A note on running specs - Que's worker system is multithreaded and therefore prone to race conditions. As such, if you've touched that code, a single spec run passing isn't a guarantee that any changes you've made haven't introduced bugs. One thing I like to do before pushing changes is rerun the specs many times and watching for hangs. You can do this from the command line with something like:
 
     for i in {1..1000}; do SEED=$i bundle exec rake; done

--- a/README.md
+++ b/README.md
@@ -6,49 +6,54 @@
 
 Que ("keɪ", or "kay") is a queue for Ruby and PostgreSQL that manages jobs using [advisory locks](http://www.postgresql.org/docs/current/static/explicit-locking.html#ADVISORY-LOCKS), which gives it several advantages over other RDBMS-backed queues:
 
-  * **Concurrency** - Workers don't block each other when trying to lock jobs, as often occurs with "SELECT FOR UPDATE"-style locking. This allows for very high throughput with a large number of workers.
-  * **Efficiency** - Locks are held in memory, so locking a job doesn't incur a disk write. These first two points are what limit performance with other queues. Under heavy load, Que's bottleneck is CPU, not I/O.
-  * **Safety** - If a Ruby process dies, the jobs it's working won't be lost, or left in a locked or ambiguous state - they immediately become available for any other worker to pick up.
+- **Concurrency** - Workers don't block each other when trying to lock jobs, as often occurs with "SELECT FOR UPDATE"-style locking. This allows for very high throughput with a large number of workers.
+- **Efficiency** - Locks are held in memory, so locking a job doesn't incur a disk write. These first two points are what limit performance with other queues. Under heavy load, Que's bottleneck is CPU, not I/O.
+- **Safety** - If a Ruby process dies, the jobs it's working won't be lost, or left in a locked or ambiguous state - they immediately become available for any other worker to pick up.
 
 Additionally, there are the general benefits of storing jobs in Postgres, alongside the rest of your data, rather than in Redis or a dedicated queue:
 
-  * **Transactional Control** - Queue a job along with other changes to your database, and it'll commit or rollback with everything else. If you're using ActiveRecord or Sequel, Que can piggyback on their connections, so setup is simple and jobs are protected by the transactions you're already using.
-  * **Atomic Backups** - Your jobs and data can be backed up together and restored as a snapshot. If your jobs relate to your data (and they usually do), there's no risk of jobs falling through the cracks during a recovery.
-  * **Fewer Dependencies** - If you're already using Postgres (and you probably should be), a separate queue is another moving part that can break.
-  * **Security** - Postgres' support for SSL connections keeps your data safe in transport, for added protection when you're running workers on cloud platforms that you can't completely control.
+- **Transactional Control** - Queue a job along with other changes to your database, and it'll commit or rollback with everything else. If you're using ActiveRecord or Sequel, Que can piggyback on their connections, so setup is simple and jobs are protected by the transactions you're already using.
+- **Atomic Backups** - Your jobs and data can be backed up together and restored as a snapshot. If your jobs relate to your data (and they usually do), there's no risk of jobs falling through the cracks during a recovery.
+- **Fewer Dependencies** - If you're already using Postgres (and you probably should be), a separate queue is another moving part that can break.
+- **Security** - Postgres' support for SSL connections keeps your data safe in transport, for added protection when you're running workers on cloud platforms that you can't completely control.
 
 Que's primary goal is reliability. You should be able to leave your application running indefinitely without worrying about jobs being lost due to a lack of transactional support, or left in limbo due to a crashing process. Que does everything it can to ensure that jobs you queue are performed exactly once (though the occasional repetition of a job can be impossible to avoid - see the docs on [how to write a reliable job](/docs/README.md#writing-reliable-jobs)).
 
 Que's secondary goal is performance. The worker process is multithreaded, so that a single process can run many jobs simultaneously.
 
 Compatibility:
+
 - MRI Ruby 2.2+
 - PostgreSQL 9.5+
 - Rails 4.1+ (optional)
 
 **Please note** - Que's job table undergoes a lot of churn when it is under high load, and like any heavily-written table, is susceptible to bloat and slowness if Postgres isn't able to clean it up. The most common cause of this is long-running transactions, so it's recommended to try to keep all transactions against the database housing Que's job table as short as possible. This is good advice to remember for any high-activity database, but bears emphasizing when using tables that undergo a lot of writes.
 
-
 ## Installation
 
 Add this line to your application's Gemfile:
 
-    gem 'que'
+```ruby
+gem 'que'
+```
 
 And then execute:
 
-    $ bundle
+```bash
+bundle
+```
 
 Or install it yourself as:
 
-    $ gem install que
-
+```bash
+gem install que
+```
 
 ## Usage
 
 First, create the queue schema in a migration. For example:
 
-``` ruby
+```ruby
 class CreateQueSchema < ActiveRecord::Migration[5.0]
   def up
     # Whenever you use Que in a migration, always specify the version you're
@@ -66,7 +71,7 @@ end
 
 Create a class for each type of job you want to run:
 
-``` ruby
+```ruby
 # app/jobs/charge_credit_card.rb
 class ChargeCreditCard < Que::Job
   # Default settings for this job. These are optional - without them, jobs
@@ -101,7 +106,7 @@ end
 
 Queue your job. Again, it's best to do this in a transaction with other changes you're making. Also note that any arguments you pass will be serialized to JSON and back again, so stick to simple types (strings, integers, floats, hashes, and arrays).
 
-``` ruby
+```ruby
 CreditCard.transaction do
   # Persist credit card information
   card = CreditCard.create(params[:credit_card])
@@ -111,17 +116,18 @@ end
 
 You can also add options to run the job after a specific time, or with a specific priority:
 
-``` ruby
+```ruby
 ChargeCreditCard.enqueue card.id, user_id: current_user.id, run_at: 1.day.from_now, priority: 5
 ```
 ## Running the Que Worker
 In order to process jobs, you must start a separate worker process outside of your main server. 
 
-```
+```bash
 bundle exec que
 ```
 
 Try running `que -h` to get a list of runtime options:
+
 ```
 $ que -h
 usage: que [options] [file/to/require] ...
@@ -139,20 +145,23 @@ If you're using ActiveRecord to dump your database's schema, please [set your sc
 Pre-1.0, the default queue name needed to be configured in order for Que to work out of the box with Rails. In 1.0 the default queue name is now 'default', as Rails expects, but when Rails enqueues some types of jobs it may try to use another queue name that isn't worked by default. You can either:
 
 * [Configure Rails](https://guides.rubyonrails.org/configuring.html) to send all internal job types to the 'default' queue by adding the following to `config/application.rb`:
-```ruby
-config.action_mailer.deliver_later_queue_name = :default
-config.action_mailbox.queues.incineration = :default
-config.action_mailbox.queues.routing = :default
-config.active_storage.queues.analysis = :default
-config.active_storage.queues.purge = :default
-```
+
+    ```ruby
+    config.action_mailer.deliver_later_queue_name = :default
+    config.action_mailbox.queues.incineration = :default
+    config.action_mailbox.queues.routing = :default
+    config.active_storage.queues.analysis = :default
+    config.active_storage.queues.purge = :default
+    ```
 
 * [Tell que](/docs#multiple-queues) to work all of these queues (less efficient because it requires polling all of them):
-```
-que -q default -q mailers -q action_mailbox_incineration -q action_mailbox_routing -q active_storage_analysis -q active_storage_purge
-```
+
+    ```bash
+    que -q default -q mailers -q action_mailbox_incineration -q action_mailbox_routing -q active_storage_analysis -q active_storage_purge
+    ```
 
 Also, if you would like to integrate Que with Active Job, you can do it by setting the adapter in `config/application.rb` or in a specific environment by setting it in `config/environments/production.rb`, for example:
+
 ```ruby
 config.active_job.queue_adapter = :que
 ```
@@ -193,32 +202,42 @@ Regarding contributions, one of the project's priorities is to keep Que as simpl
 
 A note on running specs - Que's worker system is multithreaded and therefore prone to race conditions. As such, if you've touched that code, a single spec run passing isn't a guarantee that any changes you've made haven't introduced bugs. One thing I like to do before pushing changes is rerun the specs many times and watching for hangs. You can do this from the command line with something like:
 
-    for i in {1..1000}; do SEED=$i bundle exec rake; done
+```bash
+for i in {1..1000}; do SEED=$i bundle exec rake; done
+```
 
 This will iterate the specs one thousand times, each with a different ordering. If the specs hang, note what the seed number was on that iteration. For example, if the previous specs finished with a "Randomized with seed 328", you know that there's a hang with seed 329, and you can narrow it down to a specific spec with:
 
-    for i in {1..1000}; do LOG_SPEC=true SEED=328 bundle exec rake; done
+```bash
+for i in {1..1000}; do LOG_SPEC=true SEED=328 bundle exec rake; done
+```
 
 Note that we iterate because there's no guarantee that the hang would reappear with a single additional run, so we need to rerun the specs until it reappears. The LOG_SPEC parameter will output the name and file location of each spec before it is run, so you can easily tell which spec is hanging, and you can continue narrowing things down from there.
 
 Another helpful technique is to replace an `it` spec declaration with `hit` - this will run that particular spec 100 times during the run.
 
 #### **With docker-compose**
+
 To run the specs using Docker/`docker-compose` (avoiding manual setup), use:
 
-    ./auto/test
+```bash
+./auto/test
+```
+
 The `docker-compose` file provides a convenience method for injecting your local shell aliases into the Docker container. Simply drop a file containing your alias definitions into `~/.docker-rc.d/`, and they will be available inside the container. This is helpful if you're doing interactive running/debugging with `auto/dev`.
 
 #### **Without docker-compose**
 
 You'll need to have Postgres running locally.
+
 Assuming you have a local Postgres database set up with username and password `que`, you can run
 
-```
+```bash
 DATABASE_URL=postgres://que:que@localhost/que bundle exec rake spec
 ```
 
 If for some reason you have Docker installed without `docker-compose`, a quick way to set up said database is to spin up a Docker image of your preferred Postgres version, e.g.
-```
+
+```bash
 docker run -e POSTGRES_PASSWORD=que -e POSTGRES_USER=que -p 5432:5432 -d postgres:11.0
 ```

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ If you're using ActiveRecord to dump your database's schema, please [set your sc
 
 Pre-1.0, the default queue name needed to be configured in order for Que to work out of the box with Rails. In 1.0 the default queue name is now 'default', as Rails expects, but when Rails enqueues some types of jobs it may try to use another queue name that isn't worked by default. You can either:
 
-* [Configure Rails](https://guides.rubyonrails.org/configuring.html) to send all internal job types to the 'default' queue by adding the following to `config/application.rb`:
+- [Configure Rails](https://guides.rubyonrails.org/configuring.html) to send all internal job types to the 'default' queue by adding the following to `config/application.rb`:
 
     ```ruby
     config.action_mailer.deliver_later_queue_name = :default
@@ -154,7 +154,7 @@ Pre-1.0, the default queue name needed to be configured in order for Que to work
     config.active_storage.queues.purge = :default
     ```
 
-* [Tell que](/docs#multiple-queues) to work all of these queues (less efficient because it requires polling all of them):
+- [Tell que](/docs#multiple-queues) to work all of these queues (less efficient because it requires polling all of them):
 
     ```bash
     que -q default -q mailers -q action_mailbox_incineration -q action_mailbox_routing -q active_storage_analysis -q active_storage_purge
@@ -192,9 +192,9 @@ If you have a project that uses or relates to Que, feel free to submit a PR addi
 
 ## Community and Contributing
 
-  * For bugs in the library, please feel free to [open an issue](https://github.com/que-rb/que/issues/new).
-  * For general discussion and questions/concerns that don't relate to obvious bugs, join our [Discord Server](https://discord.gg/B3EW32H).
-  * For contributions, pull requests submitted via Github are welcome.
+- For bugs in the library, please feel free to [open an issue](https://github.com/que-rb/que/issues/new).
+- For general discussion and questions/concerns that don't relate to obvious bugs, join our [Discord Server](https://discord.gg/B3EW32H).
+- For contributions, pull requests submitted via Github are welcome.
 
 Regarding contributions, one of the project's priorities is to keep Que as simple, lightweight and dependency-free as possible, and pull requests that change too much or wouldn't be useful to the majority of Que's users have a good chance of being rejected. If you're thinking of submitting a pull request that adds a new feature, consider starting a discussion in [que-talk](https://groups.google.com/forum/#!forum/que-talk) first about what it would do and how it would be implemented. If it's a sufficiently large feature, or if most of Que's users wouldn't find it useful, it may be best implemented as a standalone gem, like some of the related projects above.
 

--- a/README.md
+++ b/README.md
@@ -236,10 +236,10 @@ The [Docker Compose config](docker-compose.yml) provides a convenient way to inj
 
 #### Without Docker
 
-You'll need to have Postgres running. Assuming you have a local database set up with a username and password of `que`, you can run:
+You'll need to have Postgres running. Assuming you have it running on port 5697, with a `que-test` database, and a username & password of `que`, you can run:
 
 ```bash
-DATABASE_URL=postgres://que:que@localhost/que bundle exec rake
+DATABASE_URL=postgres://que:que@localhost:5697/que-test bundle exec rake
 ```
 
 If you don't already have Postgres, you could use Docker Compose to run just the database:

--- a/README.md
+++ b/README.md
@@ -216,17 +216,17 @@ Note that we iterate because there's no guarantee that the hang would reappear w
 
 Another helpful technique is to replace an `it` spec declaration with `hit` - this will run that particular spec 100 times during the run.
 
-#### **With docker-compose**
+#### **With docker compose**
 
-To run the specs using Docker/`docker-compose` (avoiding manual setup), use:
+To run the specs using Docker / Docker Compose (avoiding manual setup), use:
 
 ```bash
 ./auto/test
 ```
 
-The `docker-compose` file provides a convenience method for injecting your local shell aliases into the Docker container. Simply drop a file containing your alias definitions into `~/.docker-rc.d/`, and they will be available inside the container. This is helpful if you're doing interactive running/debugging with `auto/dev`.
+The [Docker Compose config](docker-compose.yml) provides a convenience method for injecting your local shell aliases into the Docker container. Simply drop a file containing your alias definitions into `~/.docker-rc.d/`, and they will be available inside the container. This is helpful if you're doing interactive running/debugging with `auto/dev`.
 
-#### **Without docker-compose**
+#### **Without docker compose**
 
 You'll need to have Postgres running locally.
 
@@ -236,7 +236,7 @@ Assuming you have a local Postgres database set up with username and password `q
 DATABASE_URL=postgres://que:que@localhost/que bundle exec rake spec
 ```
 
-If for some reason you have Docker installed without `docker-compose`, a quick way to set up said database is to spin up a Docker image of your preferred Postgres version, e.g.
+If for some reason you have Docker installed without Docker Compose, a quick way to set up said database is to spin up a Docker image of your preferred Postgres version, e.g.
 
 ```bash
 docker run -e POSTGRES_PASSWORD=que -e POSTGRES_USER=que -p 5432:5432 -d postgres:11.0

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ Another helpful technique is to replace an `it` spec declaration with `hit` - th
 
 #### With Docker
 
-We've provided a Docker environment using Docker Compose, which avoids the need to manually: install Ruby, install the gem bundle, set up Postgres, and connect to the database.
+We've provided a Dockerised environment to avoid the need to manually: install Ruby, install the gem bundle, set up Postgres, and connect to the database.
 
 To run the specs using this environment, run:
 
@@ -252,10 +252,4 @@ If you want to try a different version of Postgres, e.g. 12:
 
 ```bash
 export POSTGRES_VERSION=12
-```
-
-Or, if for some reason, you have Docker installed without Docker Compose, a quick way to set up said database is to spin up a Docker container of your preferred Postgres version, e.g.:
-
-```bash
-docker run -e POSTGRES_PASSWORD=que -e POSTGRES_USER=que -p 5432:5432 -d postgres:13
 ```

--- a/README.md
+++ b/README.md
@@ -216,28 +216,46 @@ Note that we iterate because there's no guarantee that the hang would reappear w
 
 Another helpful technique is to replace an `it` spec declaration with `hit` - this will run that particular spec 100 times during the run.
 
-#### **With docker compose**
+#### With Docker
 
-To run the specs using Docker / Docker Compose (avoiding manual setup), use:
+We've provided a Docker environment using Docker Compose, which avoids the need to manually: install Ruby, install the gem bundle, set up Postgres, and connect to the database.
+
+To run the specs using this environment, run:
 
 ```bash
 ./auto/test
 ```
 
-The [Docker Compose config](docker-compose.yml) provides a convenience method for injecting your local shell aliases into the Docker container. Simply drop a file containing your alias definitions into `~/.docker-rc.d/`, and they will be available inside the container. This is helpful if you're doing interactive running/debugging with `auto/dev`.
-
-#### **Without docker compose**
-
-You'll need to have Postgres running locally.
-
-Assuming you have a local Postgres database set up with username and password `que`, you can run
+To get a shell in the environment, run:
 
 ```bash
-DATABASE_URL=postgres://que:que@localhost/que bundle exec rake spec
+./auto/dev
 ```
 
-If for some reason you have Docker installed without Docker Compose, a quick way to set up said database is to spin up a Docker image of your preferred Postgres version, e.g.
+The [Docker Compose config](docker-compose.yml) provides a convenient way to inject your local shell aliases into the Docker container. Simply create a file containing your alias definitions (or which sources them from other files) at `~/.docker-rc.d/.docker-bashrc`, and they will be available inside the container.
+
+#### Without Docker
+
+You'll need to have Postgres running. Assuming you have a local database set up with a username and password of `que`, you can run:
 
 ```bash
-docker run -e POSTGRES_PASSWORD=que -e POSTGRES_USER=que -p 5432:5432 -d postgres:11.0
+DATABASE_URL=postgres://que:que@localhost/que bundle exec rake
+```
+
+If you don't already have Postgres, you could use Docker Compose to run just the database:
+
+```bash
+docker compose up -d db
+```
+
+If you want to try a different version of Postgres, e.g. 12:
+
+```bash
+export POSTGRES_VERSION=12
+```
+
+Or, if for some reason, you have Docker installed without Docker Compose, a quick way to set up said database is to spin up a Docker container of your preferred Postgres version, e.g.:
+
+```bash
+docker run -e POSTGRES_PASSWORD=que -e POSTGRES_USER=que -p 5432:5432 -d postgres:13
 ```

--- a/auto/dev
+++ b/auto/dev
@@ -1,0 +1,21 @@
+#!/bin/bash
+#
+# Operate in development environment
+
+set -Eeuo pipefail
+
+cd "$(dirname "$0")/.."
+
+docker-compose build dev
+
+# Delete containers and DB volume afterwards on CI
+if [[ "${CI-}" == "true" ]]; then
+  trap '{
+    echo "Stopping containers..."
+    docker-compose down
+    docker volume rm -f que_db-data
+  }' EXIT
+fi
+
+set -x
+docker-compose run --rm dev "${@-bash}"

--- a/auto/dev
+++ b/auto/dev
@@ -6,16 +6,16 @@ set -Eeuo pipefail
 
 cd "$(dirname "$0")/.."
 
-docker-compose build dev
+docker compose build dev
 
 # Delete containers and DB volume afterwards on CI
 if [[ "${CI-}" == "true" ]]; then
   trap '{
     echo "Stopping containers..."
-    docker-compose down
+    docker compose down
     docker volume rm -f que_db-data
   }' EXIT
 fi
 
 set -x
-docker-compose run --rm dev "${@-bash}"
+docker compose run --rm dev "${@-bash}"

--- a/auto/psql
+++ b/auto/psql
@@ -1,0 +1,9 @@
+#!/bin/bash
+#
+# Open a database shell
+
+set -Eeuo pipefail
+
+cd "$(dirname "$0")/.."
+
+docker-compose run --rm pg-dev psql "${@-}"

--- a/auto/psql
+++ b/auto/psql
@@ -6,4 +6,4 @@ set -Eeuo pipefail
 
 cd "$(dirname "$0")/.."
 
-docker-compose run --rm pg-dev psql "${@-}"
+docker compose run --rm pg-dev psql "${@-}"

--- a/auto/test
+++ b/auto/test
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -Eeuo pipefail
+
+"$(dirname "$0")"/dev ./scripts/test "$@"

--- a/auto/test-postgres-14
+++ b/auto/test-postgres-14
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -Eeuo pipefail
+
+export POSTGRES_VERSION=14
+
+delete_db() {
+  docker-compose down
+  docker volume rm -f que_db-data
+}
+
+trap delete_db EXIT
+
+# pre-test cleanup is necessary as the existing db container will be used if it's running (potentially with the wrong PG version)
+delete_db
+"$(dirname "$0")"/test "$@"
+delete_db

--- a/auto/test-postgres-14
+++ b/auto/test-postgres-14
@@ -5,7 +5,7 @@ set -Eeuo pipefail
 export POSTGRES_VERSION=14
 
 delete_db() {
-  docker-compose down
+  docker compose down
   docker volume rm -f que_db-data
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,46 @@
+version: "3.7"
+
+services:
+
+  dev:
+    build:
+      context: .
+      target: dev-environment
+    depends_on:
+      - db
+    volumes:
+      - .:/work
+      - ruby-2.7.5-gem-cache:/usr/local/bundle
+      - ~/.docker-rc.d/:/.docker-rc.d/:ro
+    working_dir: /work
+    entrypoint: /work/scripts/docker-entrypoint
+    command: bash
+    environment:
+      DATABASE_URL: postgres://que:que@db/que-test
+
+  db:
+    image: "postgres:${POSTGRES_VERSION-13}"
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_USER: que
+      POSTGRES_PASSWORD: que
+      POSTGRES_DB: que-test
+    ports:
+      - 5697:5432
+
+  pg-dev:
+    image: "postgres:${POSTGRES_VERSION-13}"
+    depends_on:
+      - db
+    entrypoint: []
+    command: psql
+    environment:
+      PGHOST: db
+      PGUSER: que
+      PGPASSWORD: que
+      PGDATABASE: que-test
+
+volumes:
+  db-data: ~
+  ruby-2.7.5-gem-cache: ~

--- a/scripts/docker-entrypoint
+++ b/scripts/docker-entrypoint
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -Eeuo pipefail
+
+# For using your own dotfiles within the Docker container
+if [ -f /.docker-rc.d/.docker-bashrc ]; then
+  echo "source /.docker-rc.d/.docker-bashrc" >> ~/.bashrc
+fi
+
+gem list -i -e bundler -v "$RUBY_BUNDLER_VERSION" >/dev/null || gem install bundler -v "$RUBY_BUNDLER_VERSION"
+
+bundle check || bundle install
+
+exec bundle exec "${@-bash}"

--- a/scripts/docker-entrypoint
+++ b/scripts/docker-entrypoint
@@ -9,6 +9,6 @@ fi
 
 gem list -i -e bundler -v "$RUBY_BUNDLER_VERSION" >/dev/null || gem install bundler -v "$RUBY_BUNDLER_VERSION"
 
-bundle check || bundle install
+bundle check --dry-run || bundle install
 
 exec "${@-bash}"

--- a/scripts/docker-entrypoint
+++ b/scripts/docker-entrypoint
@@ -11,4 +11,4 @@ gem list -i -e bundler -v "$RUBY_BUNDLER_VERSION" >/dev/null || gem install bund
 
 bundle check || bundle install
 
-exec bundle exec "${@-bash}"
+exec "${@-bash}"

--- a/scripts/test
+++ b/scripts/test
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -Eeuo pipefail
+
+bundle exec rake spec "$@"


### PR DESCRIPTION
Providing a Docker Compose service for running PostgreSQL, with a script for running the tests, makes it a lot easier to get started for developing Que. You no longer need to have installed & started PostgreSQL, set `DATABASE_URL` appropriately, or created a database for Que. Different versions of PostgreSQL can also be tested easily, by setting `POSTGRES_VERSION` - e.g. `auto/test-postgres-14`.

This setup follows GreenSync conventions, although `auto/test` is not used on GitHub Actions.

I've used the latest Ruby Docker image for Ruby 2.7. We can update this to Ruby 3 in https://github.com/que-rb/que/pull/319.