### PR TITLE
Add backtrace to errors

### DIFF
--- a/lib/que/worker.rb
+++ b/lib/que/worker.rb
@@ -138,7 +138,6 @@ module Que
           class:   error.class.to_s,
           message: error.message,
           backtrace: (error.backtrace || []).join("\n").slice(0, 10000),
-          cause: error.cause,
           full_message: error.full_message,
         },
       )

--- a/lib/que/worker.rb
+++ b/lib/que/worker.rb
@@ -138,7 +138,6 @@ module Que
           class:   error.class.to_s,
           message: error.message,
           backtrace: (error.backtrace || []).join("\n").slice(0, 10000),
-          full_message: error.full_message,
         },
       )
 

--- a/lib/que/worker.rb
+++ b/lib/que/worker.rb
@@ -137,6 +137,9 @@ module Que
         error: {
           class:   error.class.to_s,
           message: error.message,
+          backtrace: (error.backtrace || []).join("\n").slice(0, 10000),
+          cause: error.cause,
+          full_message: error.full_message,
         },
       )
 
@@ -164,7 +167,7 @@ module Que
           Que.execute :set_error, [
             delay,
             "#{error.class}: #{error.message}".slice(0, 500),
-            error.backtrace.join("\n").slice(0, 10000),
+            (error.backtrace || []).join("\n").slice(0, 10000),
             job.fetch(:id),
           ]
         end


### PR DESCRIPTION
We were having issues where jobs were failing, but the error `ArgumentError` wasn't providing much information about where the problem was occurring.

This change adds a backtrace to the error logs, and also changes the other instance logging of the backtrace to be a bit more paranoid, in that the `backtrace` method may return a `nil` or an array.

I'd suggest a squash merge of these commits, if that's OK.
