### PR TITLE
Add job_schema_version column

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ class CreateQueSchema < ActiveRecord::Migration[5.0]
     # Whenever you use Que in a migration, always specify the version you're
     # migrating to. If you're unsure what the current version is, check the
     # changelog.
-    Que.migrate!(version: 4)
+    Que.migrate!(version: 5)
   end
 
   def down

--- a/bin/command_line_interface.rb
+++ b/bin/command_line_interface.rb
@@ -234,7 +234,7 @@ OUTPUT
 
         output.puts(
           <<~STARTUP
-            Que started worker process with:
+            Que #{Que::VERSION} started worker process with:
               Worker threads: #{locker.workers.length} (priorities: #{locker.workers.map { |w| w.priority || 'any' }.join(', ')})
               Buffer size: #{locker.job_buffer.minimum_size}-#{locker.job_buffer.maximum_size}
               Queues:

--- a/bin/command_line_interface.spec.rb
+++ b/bin/command_line_interface.spec.rb
@@ -146,7 +146,7 @@ MSG
       assert_successful_invocation "./#{files[0]} ./#{files[1]}"
 
       assert_match(
-        %r{Que started worker process with:\n(.*\n)+Finishing Que's current jobs before exiting\.\.\.\nQue's jobs finished, exiting\.\.\.},
+        %r{Que #{Que::VERSION} started worker process with:\n(.*\n)+Finishing Que's current jobs before exiting\.\.\.\nQue's jobs finished, exiting\.\.\.},
         output.messages.join("\n"),
       )
 
@@ -445,7 +445,7 @@ MSG
       [
         (
           <<~STARTUP
-            Que started worker process with:
+            Que #{Que::VERSION} started worker process with:
               Worker threads: 6 (priorities: 1, 2, 3, 4, any, any)
               Buffer size: 0-1
               Queues:

--- a/docs/README.md
+++ b/docs/README.md
@@ -129,11 +129,11 @@ There are other docs to read if you're using [Sequel](#using-sequel) or [plain P
 After you've connected Que to the database, you can manage the jobs table. You'll want to migrate to a specific version in a migration file, to ensure that they work the same way even when you upgrade Que in the future:
 
 ```ruby
-# Update the schema to version #4.
-Que.migrate! version: 4
+# Update the schema to version #5.
+Que.migrate!(version: 5)
 
 # Remove Que's jobs table entirely.
-Que.migrate! version: 0
+Que.migrate!(version: 0)
 ```
 
 There's also a helper method to clear all jobs from the jobs table:
@@ -405,11 +405,11 @@ Some new releases of Que may require updates to the database schema. It's recomm
 ```ruby
 class UpdateQue < ActiveRecord::Migration[5.0]
   def self.up
-    Que.migrate! version: 3
+    Que.migrate!(version: 3)
   end
 
   def self.down
-    Que.migrate! version: 2
+    Que.migrate!(version: 2)
   end
 end
 ```
@@ -418,7 +418,7 @@ This will make sure that your database schema stays consistent with your codebas
 
 ```ruby
 # Change schema to version 3.
-Que.migrate! version: 3
+Que.migrate!(version: 3)
 
 # Check your current schema version.
 Que.db_version #=> 3
@@ -550,11 +550,11 @@ require 'que'
 Sequel.migration do
   up do
     Que.connection = self
-    Que.migrate! :version => 3
+    Que.migrate!(version: 5)
   end
   down do
     Que.connection = self
-    Que.migrate! :version => 0
+    Que.migrate!(version: 0)
   end
 end
 ```

--- a/lib/que/job.enqueue_spec.rb
+++ b/lib/que/job.enqueue_spec.rb
@@ -12,7 +12,7 @@ describe Que::Job, '.enqueue' do
     expected_result_class: nil,
     expected_args: [],
     expected_tags: nil,
-    expected_que_version: 1
+    expected_que_version: que_major_version
   )
 
     assert_equal 0, jobs_dataset.count

--- a/lib/que/job.enqueue_spec.rb
+++ b/lib/que/job.enqueue_spec.rb
@@ -12,7 +12,7 @@ describe Que::Job, '.enqueue' do
     expected_result_class: nil,
     expected_args: [],
     expected_tags: nil,
-    expected_que_version: Que.job_schema_version
+    expected_job_schema_version: Que.job_schema_version
   )
 
     assert_equal 0, jobs_dataset.count
@@ -44,7 +44,7 @@ describe Que::Job, '.enqueue' do
     assert_in_delta job[:run_at], expected_run_at, QueSpec::TIME_SKEW
     assert_equal expected_job_class.to_s, job[:job_class]
     assert_equal expected_args, job[:args]
-    assert_equal expected_que_version, job[:que_version]
+    assert_equal expected_job_schema_version, job[:job_schema_version]
 
     jobs_dataset.delete
   end

--- a/lib/que/job.enqueue_spec.rb
+++ b/lib/que/job.enqueue_spec.rb
@@ -12,7 +12,7 @@ describe Que::Job, '.enqueue' do
     expected_result_class: nil,
     expected_args: [],
     expected_tags: nil,
-    expected_que_version: que_major_version
+    expected_que_version: Que.major_version
   )
 
     assert_equal 0, jobs_dataset.count

--- a/lib/que/job.enqueue_spec.rb
+++ b/lib/que/job.enqueue_spec.rb
@@ -12,7 +12,7 @@ describe Que::Job, '.enqueue' do
     expected_result_class: nil,
     expected_args: [],
     expected_tags: nil,
-    expected_que_version: Que.major_version
+    expected_que_version: Que.job_schema_version
   )
 
     assert_equal 0, jobs_dataset.count

--- a/lib/que/job.enqueue_spec.rb
+++ b/lib/que/job.enqueue_spec.rb
@@ -11,7 +11,8 @@ describe Que::Job, '.enqueue' do
     expected_job_class: Que::Job,
     expected_result_class: nil,
     expected_args: [],
-    expected_tags: nil
+    expected_tags: nil,
+    expected_que_version: 1
   )
 
     assert_equal 0, jobs_dataset.count
@@ -43,6 +44,7 @@ describe Que::Job, '.enqueue' do
     assert_in_delta job[:run_at], expected_run_at, QueSpec::TIME_SKEW
     assert_equal expected_job_class.to_s, job[:job_class]
     assert_equal expected_args, job[:args]
+    assert_equal expected_que_version, job[:que_version]
 
     jobs_dataset.delete
   end

--- a/lib/que/job.rb
+++ b/lib/que/job.rb
@@ -21,7 +21,7 @@ module Que
           $4::text,
           coalesce($5, '[]')::jsonb,
           coalesce($6, '{}')::jsonb,
-          1
+          #{Gem::Version.new(Que::VERSION).segments.first}
         )
         RETURNING *
       }

--- a/lib/que/job.rb
+++ b/lib/que/job.rb
@@ -21,7 +21,7 @@ module Que
           $4::text,
           coalesce($5, '[]')::jsonb,
           coalesce($6, '{}')::jsonb,
-          #{Que.major_version}
+          #{Que.job_schema_version}
         )
         RETURNING *
       }

--- a/lib/que/job.rb
+++ b/lib/que/job.rb
@@ -12,7 +12,7 @@ module Que
     SQL[:insert_job] =
       %{
         INSERT INTO public.que_jobs
-        (queue, priority, run_at, job_class, args, data)
+        (queue, priority, run_at, job_class, args, data, que_version)
         VALUES
         (
           coalesce($1, 'default')::text,
@@ -20,7 +20,8 @@ module Que
           coalesce($3, now())::timestamptz,
           $4::text,
           coalesce($5, '[]')::jsonb,
-          coalesce($6, '{}')::jsonb
+          coalesce($6, '{}')::jsonb,
+          1
         )
         RETURNING *
       }

--- a/lib/que/job.rb
+++ b/lib/que/job.rb
@@ -21,7 +21,7 @@ module Que
           $4::text,
           coalesce($5, '[]')::jsonb,
           coalesce($6, '{}')::jsonb,
-          #{Gem::Version.new(Que::VERSION).segments.first}
+          #{Que.major_version}
         )
         RETURNING *
       }

--- a/lib/que/job.rb
+++ b/lib/que/job.rb
@@ -12,7 +12,7 @@ module Que
     SQL[:insert_job] =
       %{
         INSERT INTO public.que_jobs
-        (queue, priority, run_at, job_class, args, data, que_version)
+        (queue, priority, run_at, job_class, args, data, job_schema_version)
         VALUES
         (
           coalesce($1, 'default')::text,

--- a/lib/que/locker.rb
+++ b/lib/que/locker.rb
@@ -279,7 +279,7 @@ module Que
         CURRENT_HOSTNAME,
         !!@listener,
         "{\"#{@queue_names.join('","')}\"}",
-        Que.major_version,
+        Que.job_schema_version,
       ]
     end
 

--- a/lib/que/locker.rb
+++ b/lib/que/locker.rb
@@ -279,7 +279,7 @@ module Que
         CURRENT_HOSTNAME,
         !!@listener,
         "{\"#{@queue_names.join('","')}\"}",
-        Gem::Version.new(Que::VERSION).segments.first,
+        Que.major_version,
       ]
     end
 

--- a/lib/que/locker.rb
+++ b/lib/que/locker.rb
@@ -24,8 +24,8 @@ module Que
 
   SQL[:register_locker] =
     %{
-      INSERT INTO public.que_lockers (pid, worker_count, worker_priorities, ruby_pid, ruby_hostname, listening, queues)
-      VALUES (pg_backend_pid(), $1::integer, $2::integer[], $3::integer, $4::text, $5::boolean, $6::text[])
+      INSERT INTO public.que_lockers (pid, worker_count, worker_priorities, ruby_pid, ruby_hostname, listening, queues, que_version)
+      VALUES (pg_backend_pid(), $1::integer, $2::integer[], $3::integer, $4::text, $5::boolean, $6::text[], $7::integer)
     }
 
   class Locker
@@ -279,6 +279,7 @@ module Que
         CURRENT_HOSTNAME,
         !!@listener,
         "{\"#{@queue_names.join('","')}\"}",
+        Gem::Version.new(Que::VERSION).segments.first,
       ]
     end
 

--- a/lib/que/locker.rb
+++ b/lib/que/locker.rb
@@ -24,7 +24,7 @@ module Que
 
   SQL[:register_locker] =
     %{
-      INSERT INTO public.que_lockers (pid, worker_count, worker_priorities, ruby_pid, ruby_hostname, listening, queues, que_version)
+      INSERT INTO public.que_lockers (pid, worker_count, worker_priorities, ruby_pid, ruby_hostname, listening, queues, job_schema_version)
       VALUES (pg_backend_pid(), $1::integer, $2::integer[], $3::integer, $4::text, $5::boolean, $6::text[], $7::integer)
     }
 

--- a/lib/que/locker.spec.rb
+++ b/lib/que/locker.spec.rb
@@ -117,7 +117,7 @@ describe Que::Locker do
         worker_priorities: Sequel.pg_array([1, 2, 3, 4], :integer),
         queues:            Sequel.pg_array(['']),
         listening:         true,
-        que_version:       que_major_version,
+        que_version:       Que.major_version,
       )
 
       locker
@@ -247,7 +247,7 @@ describe Que::Locker do
 
       Que.execute <<~SQL
         INSERT INTO que_jobs (job_class, priority, que_version)
-        SELECT 'Que::Job', 1, #{que_major_version}
+        SELECT 'Que::Job', 1, #{Que.major_version}
         FROM generate_series(1, 10) AS i;
       SQL
 
@@ -260,7 +260,7 @@ describe Que::Locker do
     it "should repeat batch polls until there are no more available jobs" do
       Que.execute <<-SQL
         INSERT INTO que_jobs (job_class, priority, que_version)
-        SELECT 'Que::Job', 1, #{que_major_version}
+        SELECT 'Que::Job', 1, #{Que.major_version}
         FROM generate_series(1, 100) AS i;
       SQL
 
@@ -360,11 +360,11 @@ describe Que::Locker do
 
       Que.execute <<-SQL
         INSERT INTO que_jobs (job_class, priority, queue, que_version)
-        SELECT 'BlockJob', 60, 'queue_1', #{que_major_version}
+        SELECT 'BlockJob', 60, 'queue_1', #{Que.major_version}
         FROM generate_series(1, 100) AS i;
 
         INSERT INTO que_jobs (job_class, priority, queue, que_version)
-        SELECT 'BlockJob', 10, 'queue_2', #{que_major_version}
+        SELECT 'BlockJob', 10, 'queue_2', #{Que.major_version}
         FROM generate_series(1, 100) AS i;
       SQL
 
@@ -432,7 +432,7 @@ describe Que::Locker do
       sleep_until_equal(1) { DB[:que_lockers].count }
 
       DB.transaction do
-        id = jobs_dataset.insert(job_class: "BlockJob", que_version: que_major_version)
+        id = jobs_dataset.insert(job_class: "BlockJob", que_version: Que.major_version)
         assert_equal 1, jobs_dataset.where(id: id).delete
       end
 
@@ -446,7 +446,7 @@ describe Que::Locker do
       sleep_until_equal(1) { DB[:que_lockers].count }
 
       DB.transaction do
-        id = jobs_dataset.insert(job_class: "BlockJob", que_version: que_major_version)
+        id = jobs_dataset.insert(job_class: "BlockJob", que_version: Que.major_version)
         assert_equal 1, jobs_dataset.where(id: id).update(finished_at: Time.now)
       end
 
@@ -459,7 +459,7 @@ describe Que::Locker do
       sleep_until_equal(1) { DB[:que_lockers].count }
 
       DB.transaction do
-        id = jobs_dataset.insert(job_class: "BlockJob", que_version: que_major_version)
+        id = jobs_dataset.insert(job_class: "BlockJob", que_version: Que.major_version)
         assert_equal 1, jobs_dataset.where(id: id).update(expired_at: Time.now)
       end
 
@@ -604,7 +604,7 @@ describe Que::Locker do
       sleep_until_equal(1) { DB[:que_lockers].count }
 
       id_other = jobs_dataset.insert(job_class: "BlockJob", que_version: 999_999)
-      id_current = jobs_dataset.insert(job_class: "BlockJob", que_version: que_major_version)
+      id_current = jobs_dataset.insert(job_class: "BlockJob", que_version: Que.major_version)
 
       sleep_until { locked_ids.include?(id_current) }
 
@@ -621,7 +621,7 @@ describe Que::Locker do
       sleep_until_equal(1) { DB[:que_lockers].count }
 
       id_other = jobs_dataset.insert(job_class: "BlockJob", que_version: 999_999)
-      id_current = jobs_dataset.insert(job_class: "BlockJob", que_version: que_major_version)
+      id_current = jobs_dataset.insert(job_class: "BlockJob", que_version: Que.major_version)
 
       sleep_until { locked_ids.include?(id_current) }
 
@@ -729,11 +729,9 @@ describe Que::Locker do
               conn.execute "BEGIN"
               conn.execute "INSERT INTO test_data (job_id, count) VALUES (#{que_attrs[:id]}, 1) ON CONFLICT (job_id) DO UPDATE SET count = test_data.count + 1"
 
-              que_major_version = Gem::Version.new(Que::VERSION).segments.first
-
               if runs < 10
                 delay = rand > 0.5 ? 1 : 0
-                conn.execute(%(INSERT INTO que_jobs (job_class, args, run_at, que_version) VALUES ('QueSpec::RunOnceTestJob', '[{"runs":#{runs + 1},"index":#{index}}]', now() + '#{delay} microseconds', #{que_major_version})))
+                conn.execute(%(INSERT INTO que_jobs (job_class, args, run_at, que_version) VALUES ('QueSpec::RunOnceTestJob', '[{"runs":#{runs + 1},"index":#{index}}]', now() + '#{delay} microseconds', #{Que.major_version})))
               end
 
               finish

--- a/lib/que/migrations.rb
+++ b/lib/que/migrations.rb
@@ -4,7 +4,7 @@ module Que
   module Migrations
     # In order to ship a schema change, add the relevant up and down sql files
     # to the migrations directory, and bump the version here.
-    CURRENT_VERSION = 4
+    CURRENT_VERSION = 5
 
     class << self
       def migrate!(version:)
@@ -28,7 +28,6 @@ module Que
               step,
               direction,
             ].join('/') << '.sql'
-
             Que.execute(File.read(filename))
           end
 

--- a/lib/que/migrations.work_job_trigger_spec.rb
+++ b/lib/que/migrations.work_job_trigger_spec.rb
@@ -12,6 +12,7 @@ describe Que::Migrations, "job_available trigger" do
       ruby_hostname:     Socket.gethostname,
       queues:            Sequel.pg_array(['default']),
       listening:         true,
+      que_version:       que_major_version,
     }
   end
 

--- a/lib/que/migrations.work_job_trigger_spec.rb
+++ b/lib/que/migrations.work_job_trigger_spec.rb
@@ -12,7 +12,7 @@ describe Que::Migrations, "job_available trigger" do
       ruby_hostname:     Socket.gethostname,
       queues:            Sequel.pg_array(['default']),
       listening:         true,
-      que_version:       que_major_version,
+      que_version:       Que.major_version,
     }
   end
 

--- a/lib/que/migrations.work_job_trigger_spec.rb
+++ b/lib/que/migrations.work_job_trigger_spec.rb
@@ -12,7 +12,7 @@ describe Que::Migrations, "job_available trigger" do
       ruby_hostname:     Socket.gethostname,
       queues:            Sequel.pg_array(['default']),
       listening:         true,
-      que_version:       Que.major_version,
+      que_version:       Que.job_schema_version,
     }
   end
 

--- a/lib/que/migrations.work_job_trigger_spec.rb
+++ b/lib/que/migrations.work_job_trigger_spec.rb
@@ -5,14 +5,14 @@ require 'spec_helper'
 describe Que::Migrations, "job_available trigger" do
   let :locker_attrs do
     {
-      pid:               1,
-      worker_count:      4,
-      worker_priorities: Sequel.pg_array([1, 2, 3, 4], :integer),
-      ruby_pid:          Process.pid,
-      ruby_hostname:     Socket.gethostname,
-      queues:            Sequel.pg_array(['default']),
-      listening:         true,
-      que_version:       Que.job_schema_version,
+      pid:                1,
+      worker_count:       4,
+      worker_priorities:  Sequel.pg_array([1, 2, 3, 4], :integer),
+      ruby_pid:           Process.pid,
+      ruby_hostname:      Socket.gethostname,
+      queues:             Sequel.pg_array(['default']),
+      listening:          true,
+      job_schema_version: Que.job_schema_version,
     }
   end
 

--- a/lib/que/migrations/4/up.sql
+++ b/lib/que/migrations/4/up.sql
@@ -146,7 +146,9 @@ CREATE FUNCTION que_job_notify() RETURNS trigger AS $$
         FROM (
           SELECT *
           FROM public.que_lockers ql, generate_series(1, ql.worker_count) AS id
-          WHERE listening AND queues @> ARRAY[NEW.queue]
+          WHERE
+            listening AND
+            queues @> ARRAY[NEW.queue]
           ORDER BY md5(pid::text || id::text)
         ) t1
       ) t2

--- a/lib/que/migrations/5/down.sql
+++ b/lib/que/migrations/5/down.sql
@@ -1,13 +1,13 @@
 DROP TRIGGER que_job_notify ON que_jobs;
 DROP FUNCTION que_job_notify();
 
-DROP INDEX que_poll_idx_with_que_version;
+DROP INDEX que_poll_idx_with_job_schema_version;
 
 ALTER TABLE que_jobs
-  DROP COLUMN que_version;
+  DROP COLUMN job_schema_version;
 
 ALTER TABLE que_lockers
-  DROP COLUMN que_version;
+  DROP COLUMN job_schema_version;
 
 CREATE FUNCTION que_job_notify() RETURNS trigger AS $$
   DECLARE

--- a/lib/que/migrations/5/down.sql
+++ b/lib/que/migrations/5/down.sql
@@ -1,3 +1,73 @@
+DROP TRIGGER que_job_notify ON que_jobs;
+DROP FUNCTION que_job_notify();
+
 DROP INDEX que_poll_idx_with_que_version;
+
 ALTER TABLE que_jobs
   DROP COLUMN que_version;
+
+ALTER TABLE que_lockers
+  DROP COLUMN que_version;
+
+CREATE FUNCTION que_job_notify() RETURNS trigger AS $$
+  DECLARE
+    locker_pid integer;
+    sort_key json;
+  BEGIN
+    -- Don't do anything if the job is scheduled for a future time.
+    IF NEW.run_at IS NOT NULL AND NEW.run_at > now() THEN
+      RETURN null;
+    END IF;
+
+    -- Pick a locker to notify of the job's insertion, weighted by their number
+    -- of workers. Should bounce pseudorandomly between lockers on each
+    -- invocation, hence the md5-ordering, but still touch each one equally,
+    -- hence the modulo using the job_id.
+    SELECT pid
+    INTO locker_pid
+    FROM (
+      SELECT *, last_value(row_number) OVER () + 1 AS count
+      FROM (
+        SELECT *, row_number() OVER () - 1 AS row_number
+        FROM (
+          SELECT *
+          FROM public.que_lockers ql, generate_series(1, ql.worker_count) AS id
+          WHERE
+            listening AND
+            queues @> ARRAY[NEW.queue]
+          ORDER BY md5(pid::text || id::text)
+        ) t1
+      ) t2
+    ) t3
+    WHERE NEW.id % count = row_number;
+
+    IF locker_pid IS NOT NULL THEN
+      -- There's a size limit to what can be broadcast via LISTEN/NOTIFY, so
+      -- rather than throw errors when someone enqueues a big job, just
+      -- broadcast the most pertinent information, and let the locker query for
+      -- the record after it's taken the lock. The worker will have to hit the
+      -- DB in order to make sure the job is still visible anyway.
+      SELECT row_to_json(t)
+      INTO sort_key
+      FROM (
+        SELECT
+          'job_available' AS message_type,
+          NEW.queue       AS queue,
+          NEW.priority    AS priority,
+          NEW.id          AS id,
+          -- Make sure we output timestamps as UTC ISO 8601
+          to_char(NEW.run_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"') AS run_at
+      ) t;
+
+      PERFORM pg_notify('que_listener_' || locker_pid::text, sort_key::text);
+    END IF;
+
+    RETURN null;
+  END
+$$
+LANGUAGE plpgsql;
+
+CREATE TRIGGER que_job_notify
+  AFTER INSERT ON que_jobs
+  FOR EACH ROW
+  EXECUTE PROCEDURE public.que_job_notify();

--- a/lib/que/migrations/5/down.sql
+++ b/lib/que/migrations/5/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE que_jobs
+  DROP COLUMN que_version;

--- a/lib/que/migrations/5/down.sql
+++ b/lib/que/migrations/5/down.sql
@@ -1,2 +1,3 @@
+DROP INDEX que_poll_idx_with_que_version;
 ALTER TABLE que_jobs
   DROP COLUMN que_version;

--- a/lib/que/migrations/5/up.sql
+++ b/lib/que/migrations/5/up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE que_jobs
+  ADD COLUMN que_version INTEGER DEFAULT 1;

--- a/lib/que/migrations/5/up.sql
+++ b/lib/que/migrations/5/up.sql
@@ -1,2 +1,3 @@
 ALTER TABLE que_jobs
   ADD COLUMN que_version INTEGER DEFAULT 1;
+CREATE INDEX que_poll_idx_with_que_version ON que_jobs (que_version, queue, priority, run_at, id) WHERE (finished_at IS NULL AND expired_at IS NULL);

--- a/lib/que/migrations/5/up.sql
+++ b/lib/que/migrations/5/up.sql
@@ -2,13 +2,13 @@ DROP TRIGGER que_job_notify ON que_jobs;
 DROP FUNCTION que_job_notify();
 
 ALTER TABLE que_jobs
-  ADD COLUMN que_version INTEGER DEFAULT 1;
+  ADD COLUMN job_schema_version INTEGER DEFAULT 1;
 
 ALTER TABLE que_lockers
-  ADD COLUMN que_version INTEGER DEFAULT 1;
+  ADD COLUMN job_schema_version INTEGER DEFAULT 1;
 
-CREATE INDEX que_poll_idx_with_que_version
-  ON que_jobs (que_version, queue, priority, run_at, id)
+CREATE INDEX que_poll_idx_with_job_schema_version
+  ON que_jobs (job_schema_version, queue, priority, run_at, id)
   WHERE (finished_at IS NULL AND expired_at IS NULL);
 
 CREATE FUNCTION que_job_notify() RETURNS trigger AS $$
@@ -37,7 +37,7 @@ CREATE FUNCTION que_job_notify() RETURNS trigger AS $$
           WHERE
             listening AND
             queues @> ARRAY[NEW.queue] AND
-            ql.que_version = NEW.que_version
+            ql.job_schema_version = NEW.job_schema_version
           ORDER BY md5(pid::text || id::text)
         ) t1
       ) t2

--- a/lib/que/migrations/5/up.sql
+++ b/lib/que/migrations/5/up.sql
@@ -1,3 +1,76 @@
+DROP TRIGGER que_job_notify ON que_jobs;
+DROP FUNCTION que_job_notify();
+
 ALTER TABLE que_jobs
   ADD COLUMN que_version INTEGER DEFAULT 1;
-CREATE INDEX que_poll_idx_with_que_version ON que_jobs (que_version, queue, priority, run_at, id) WHERE (finished_at IS NULL AND expired_at IS NULL);
+
+ALTER TABLE que_lockers
+  ADD COLUMN que_version INTEGER DEFAULT 1;
+
+CREATE INDEX que_poll_idx_with_que_version
+  ON que_jobs (que_version, queue, priority, run_at, id)
+  WHERE (finished_at IS NULL AND expired_at IS NULL);
+
+CREATE FUNCTION que_job_notify() RETURNS trigger AS $$
+  DECLARE
+    locker_pid integer;
+    sort_key json;
+  BEGIN
+    -- Don't do anything if the job is scheduled for a future time.
+    IF NEW.run_at IS NOT NULL AND NEW.run_at > now() THEN
+      RETURN null;
+    END IF;
+
+    -- Pick a locker to notify of the job's insertion, weighted by their number
+    -- of workers. Should bounce pseudorandomly between lockers on each
+    -- invocation, hence the md5-ordering, but still touch each one equally,
+    -- hence the modulo using the job_id.
+    SELECT pid
+    INTO locker_pid
+    FROM (
+      SELECT *, last_value(row_number) OVER () + 1 AS count
+      FROM (
+        SELECT *, row_number() OVER () - 1 AS row_number
+        FROM (
+          SELECT *
+          FROM public.que_lockers ql, generate_series(1, ql.worker_count) AS id
+          WHERE
+            listening AND
+            queues @> ARRAY[NEW.queue] AND
+            ql.que_version = NEW.que_version
+          ORDER BY md5(pid::text || id::text)
+        ) t1
+      ) t2
+    ) t3
+    WHERE NEW.id % count = row_number;
+
+    IF locker_pid IS NOT NULL THEN
+      -- There's a size limit to what can be broadcast via LISTEN/NOTIFY, so
+      -- rather than throw errors when someone enqueues a big job, just
+      -- broadcast the most pertinent information, and let the locker query for
+      -- the record after it's taken the lock. The worker will have to hit the
+      -- DB in order to make sure the job is still visible anyway.
+      SELECT row_to_json(t)
+      INTO sort_key
+      FROM (
+        SELECT
+          'job_available' AS message_type,
+          NEW.queue       AS queue,
+          NEW.priority    AS priority,
+          NEW.id          AS id,
+          -- Make sure we output timestamps as UTC ISO 8601
+          to_char(NEW.run_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"') AS run_at
+      ) t;
+
+      PERFORM pg_notify('que_listener_' || locker_pid::text, sort_key::text);
+    END IF;
+
+    RETURN null;
+  END
+$$
+LANGUAGE plpgsql;
+
+CREATE TRIGGER que_job_notify
+  AFTER INSERT ON que_jobs
+  FOR EACH ROW
+  EXECUTE PROCEDURE public.que_job_notify();

--- a/lib/que/poller.rb
+++ b/lib/que/poller.rb
@@ -68,7 +68,7 @@ module Que
             SELECT j
             FROM public.que_jobs AS j
             WHERE queue = $1::text
-              AND que_version = 1
+              AND que_version = #{Gem::Version.new(Que::VERSION).segments.first}
               AND NOT id = ANY($2::bigint[])
               AND priority <= pg_temp.que_highest_remaining_priority($3::jsonb)
               AND run_at <= now()
@@ -89,7 +89,7 @@ module Que
                   SELECT j
                   FROM public.que_jobs AS j
                   WHERE queue = $1::text
-                    AND que_version = 1
+                    AND que_version = #{Gem::Version.new(Que::VERSION).segments.first}
                     AND NOT id = ANY($2::bigint[])
                     AND priority <= pg_temp.que_highest_remaining_priority(jobs.remaining_priorities)
                     AND run_at <= now()

--- a/lib/que/poller.rb
+++ b/lib/que/poller.rb
@@ -68,6 +68,7 @@ module Que
             SELECT j
             FROM public.que_jobs AS j
             WHERE queue = $1::text
+              AND que_version = 1
               AND NOT id = ANY($2::bigint[])
               AND priority <= pg_temp.que_highest_remaining_priority($3::jsonb)
               AND run_at <= now()
@@ -88,6 +89,7 @@ module Que
                   SELECT j
                   FROM public.que_jobs AS j
                   WHERE queue = $1::text
+                    AND que_version = 1
                     AND NOT id = ANY($2::bigint[])
                     AND priority <= pg_temp.que_highest_remaining_priority(jobs.remaining_priorities)
                     AND run_at <= now()

--- a/lib/que/poller.rb
+++ b/lib/que/poller.rb
@@ -68,7 +68,7 @@ module Que
             SELECT j
             FROM public.que_jobs AS j
             WHERE queue = $1::text
-              AND que_version = #{Gem::Version.new(Que::VERSION).segments.first}
+              AND que_version = #{Que.major_version}
               AND NOT id = ANY($2::bigint[])
               AND priority <= pg_temp.que_highest_remaining_priority($3::jsonb)
               AND run_at <= now()
@@ -89,7 +89,7 @@ module Que
                   SELECT j
                   FROM public.que_jobs AS j
                   WHERE queue = $1::text
-                    AND que_version = #{Gem::Version.new(Que::VERSION).segments.first}
+                    AND que_version = #{Que.major_version}
                     AND NOT id = ANY($2::bigint[])
                     AND priority <= pg_temp.que_highest_remaining_priority(jobs.remaining_priorities)
                     AND run_at <= now()

--- a/lib/que/poller.rb
+++ b/lib/que/poller.rb
@@ -68,7 +68,7 @@ module Que
             SELECT j
             FROM public.que_jobs AS j
             WHERE queue = $1::text
-              AND que_version = #{Que.major_version}
+              AND que_version = #{Que.job_schema_version}
               AND NOT id = ANY($2::bigint[])
               AND priority <= pg_temp.que_highest_remaining_priority($3::jsonb)
               AND run_at <= now()
@@ -89,7 +89,7 @@ module Que
                   SELECT j
                   FROM public.que_jobs AS j
                   WHERE queue = $1::text
-                    AND que_version = #{Que.major_version}
+                    AND que_version = #{Que.job_schema_version}
                     AND NOT id = ANY($2::bigint[])
                     AND priority <= pg_temp.que_highest_remaining_priority(jobs.remaining_priorities)
                     AND run_at <= now()

--- a/lib/que/poller.rb
+++ b/lib/que/poller.rb
@@ -68,7 +68,7 @@ module Que
             SELECT j
             FROM public.que_jobs AS j
             WHERE queue = $1::text
-              AND que_version = #{Que.job_schema_version}
+              AND job_schema_version = #{Que.job_schema_version}
               AND NOT id = ANY($2::bigint[])
               AND priority <= pg_temp.que_highest_remaining_priority($3::jsonb)
               AND run_at <= now()
@@ -89,7 +89,7 @@ module Que
                   SELECT j
                   FROM public.que_jobs AS j
                   WHERE queue = $1::text
-                    AND que_version = #{Que.job_schema_version}
+                    AND job_schema_version = #{Que.job_schema_version}
                     AND NOT id = ANY($2::bigint[])
                     AND priority <= pg_temp.que_highest_remaining_priority(jobs.remaining_priorities)
                     AND run_at <= now()

--- a/lib/que/poller.spec.rb
+++ b/lib/que/poller.spec.rb
@@ -124,7 +124,7 @@ describe Que::Poller do
       [10, 20, 30, 40, 50].each {|p| priorities += ([p] * 10)}
       priorities.shuffle!
 
-      jobs_dataset.import([:job_class, :priority, :que_version], priorities.map{|p| ["Que::Job", p, Que.job_schema_version]})
+      jobs_dataset.import([:job_class, :priority, :job_schema_version], priorities.map{|p| ["Que::Job", p, Que.job_schema_version]})
     end
 
     def assert_poll(priorities:, locked:)
@@ -221,7 +221,7 @@ describe Que::Poller do
     4.times { q1.pop }
 
     Que.execute <<-SQL
-      INSERT INTO que_jobs (job_class, priority, que_version)
+      INSERT INTO que_jobs (job_class, priority, job_schema_version)
       SELECT 'Que::Job', 1, #{Que.job_schema_version}
       FROM generate_series(1, 100) AS i;
     SQL

--- a/lib/que/poller.spec.rb
+++ b/lib/que/poller.spec.rb
@@ -124,7 +124,7 @@ describe Que::Poller do
       [10, 20, 30, 40, 50].each {|p| priorities += ([p] * 10)}
       priorities.shuffle!
 
-      jobs_dataset.import([:job_class, :priority, :que_version], priorities.map{|p| ["Que::Job", p, Que.major_version]})
+      jobs_dataset.import([:job_class, :priority, :que_version], priorities.map{|p| ["Que::Job", p, Que.job_schema_version]})
     end
 
     def assert_poll(priorities:, locked:)
@@ -222,7 +222,7 @@ describe Que::Poller do
 
     Que.execute <<-SQL
       INSERT INTO que_jobs (job_class, priority, que_version)
-      SELECT 'Que::Job', 1, #{Que.major_version}
+      SELECT 'Que::Job', 1, #{Que.job_schema_version}
       FROM generate_series(1, 100) AS i;
     SQL
 

--- a/lib/que/poller.spec.rb
+++ b/lib/que/poller.spec.rb
@@ -124,7 +124,7 @@ describe Que::Poller do
       [10, 20, 30, 40, 50].each {|p| priorities += ([p] * 10)}
       priorities.shuffle!
 
-      jobs_dataset.import([:job_class, :priority], priorities.map{|p| ["Que::Job", p]})
+      jobs_dataset.import([:job_class, :priority, :que_version], priorities.map{|p| ["Que::Job", p, que_major_version]})
     end
 
     def assert_poll(priorities:, locked:)
@@ -221,8 +221,8 @@ describe Que::Poller do
     4.times { q1.pop }
 
     Que.execute <<-SQL
-      INSERT INTO que_jobs (job_class, priority)
-      SELECT 'Que::Job', 1
+      INSERT INTO que_jobs (job_class, priority, que_version)
+      SELECT 'Que::Job', 1, #{que_major_version}
       FROM generate_series(1, 100) AS i;
     SQL
 

--- a/lib/que/poller.spec.rb
+++ b/lib/que/poller.spec.rb
@@ -124,7 +124,7 @@ describe Que::Poller do
       [10, 20, 30, 40, 50].each {|p| priorities += ([p] * 10)}
       priorities.shuffle!
 
-      jobs_dataset.import([:job_class, :priority, :que_version], priorities.map{|p| ["Que::Job", p, que_major_version]})
+      jobs_dataset.import([:job_class, :priority, :que_version], priorities.map{|p| ["Que::Job", p, Que.major_version]})
     end
 
     def assert_poll(priorities:, locked:)
@@ -222,7 +222,7 @@ describe Que::Poller do
 
     Que.execute <<-SQL
       INSERT INTO que_jobs (job_class, priority, que_version)
-      SELECT 'Que::Job', 1, #{que_major_version}
+      SELECT 'Que::Job', 1, #{Que.major_version}
       FROM generate_series(1, 100) AS i;
     SQL
 

--- a/lib/que/utils/introspection.spec.rb
+++ b/lib/que/utils/introspection.spec.rb
@@ -67,7 +67,7 @@ describe Que::Utils::Introspection do
       state = states.first
       assert_equal \
         %i(priority run_at id job_class error_count last_error_message queue
-          last_error_backtrace finished_at expired_at args data que_version ruby_hostname ruby_pid),
+          last_error_backtrace finished_at expired_at args data job_schema_version ruby_hostname ruby_pid),
         state.keys
 
       assert_equal 2, state[:priority]

--- a/lib/que/utils/introspection.spec.rb
+++ b/lib/que/utils/introspection.spec.rb
@@ -67,7 +67,7 @@ describe Que::Utils::Introspection do
       state = states.first
       assert_equal \
         %i(priority run_at id job_class error_count last_error_message queue
-          last_error_backtrace finished_at expired_at args data ruby_hostname ruby_pid),
+          last_error_backtrace finished_at expired_at args data que_version ruby_hostname ruby_pid),
         state.keys
 
       assert_equal 2, state[:priority]

--- a/lib/que/version.rb
+++ b/lib/que/version.rb
@@ -4,6 +4,6 @@ module Que
   VERSION = '1.2.0'
 
   def self.job_schema_version
-    Gem::Version.new(Que::VERSION).segments.first
+    1
   end
 end

--- a/lib/que/version.rb
+++ b/lib/que/version.rb
@@ -3,7 +3,7 @@
 module Que
   VERSION = '1.2.0'
 
-  def self.major_version
+  def self.job_schema_version
     Gem::Version.new(Que::VERSION).segments.first
   end
 end

--- a/lib/que/version.rb
+++ b/lib/que/version.rb
@@ -2,4 +2,8 @@
 
 module Que
   VERSION = '1.2.0'
+
+  def self.major_version
+    Gem::Version.new(Que::VERSION).segments.first
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -218,6 +218,10 @@ class QueSpec < Minitest::Spec
     end
   end
 
+  def que_major_version
+    Gem::Version.new(Que::VERSION).segments.first
+  end
+
   def jobs_dataset
     DB[:que_jobs]
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -218,10 +218,6 @@ class QueSpec < Minitest::Spec
     end
   end
 
-  def que_major_version
-    Gem::Version.new(Que::VERSION).segments.first
-  end
-
   def jobs_dataset
     DB[:que_jobs]
   end


### PR DESCRIPTION
This is a change best made prior to merging #319.

We've added the `job_schema_version` column to the `que_jobs` table.
This will allow us to:
- In Que 2.x, start recording the `que_version` as 2
- Build a migration process from 1.x to 2.x whereby Que workers only process jobs that were enqueued with their version of Que.
- In Que 2.x, we can delete the old poller index.

We're thinking this will require a major version bump due to the additional DB migrations but we're open to suggestions.