### PR TITLE
Log config on startup

### DIFF
--- a/bin/command_line_interface.rb
+++ b/bin/command_line_interface.rb
@@ -232,6 +232,7 @@ OUTPUT
         $stop_que_executable = false
         %w[INT TERM].each { |signal| trap(signal) { $stop_que_executable = true } }
 
+        output.puts "Que started with #{locker.workers.length} workers (priorities: #{locker.workers.map(&:priority)})"
         output.puts "Que waiting for jobs..."
 
         loop do

--- a/bin/command_line_interface.rb
+++ b/bin/command_line_interface.rb
@@ -232,8 +232,16 @@ OUTPUT
         $stop_que_executable = false
         %w[INT TERM].each { |signal| trap(signal) { $stop_que_executable = true } }
 
-        output.puts "Que started with #{locker.workers.length} workers (priorities: #{locker.workers.map(&:priority)})"
-        output.puts "Que waiting for jobs..."
+        output.puts(
+          <<~STARTUP
+            Que started worker process with:
+              Worker threads: #{locker.workers.length} (priorities: #{locker.workers.map { |w| w.priority || 'any' }.join(', ')})
+              Buffer size: #{locker.job_buffer.minimum_size}-#{locker.job_buffer.maximum_size}
+              Queues:
+            #{locker.queues.map { |queue, interval| "    - #{queue} (poll interval: #{interval}s)" }.join("\n")}
+            Que waiting for jobs...
+          STARTUP
+        )
 
         loop do
           sleep 0.01

--- a/bin/command_line_interface.spec.rb
+++ b/bin/command_line_interface.spec.rb
@@ -147,6 +147,7 @@ MSG
 
       assert_equal(
         [
+          "Que started with 6 workers (priorities: [10, 30, 50, nil, nil, nil])",
           "Que waiting for jobs...",
           "\nFinishing Que's current jobs before exiting...",
           "Que's jobs finished, exiting...",

--- a/bin/command_line_interface.spec.rb
+++ b/bin/command_line_interface.spec.rb
@@ -437,7 +437,7 @@ MSG
     file_name = write_file
 
     assert_successful_invocation(
-      "./#{file_name} -w 5 -p 1,2,3,4,5,6,7 -i 1.2 -q a=10 -q b=20.05 -q c --minimum-buffer-size 0 --maximum-buffer-size 1",
+      "./#{file_name} -w 6 -p 1,2,3,4 -i 1.2 -q a=10 -q b=20.05 -q c --minimum-buffer-size 0 --maximum-buffer-size 1",
       queue_name: 'a',
     )
 
@@ -446,7 +446,7 @@ MSG
         (
           <<~STARTUP
             Que started worker process with:
-              Worker threads: 5 (priorities: 1, 2, 3, 4, 5)
+              Worker threads: 6 (priorities: 1, 2, 3, 4, any, any)
               Buffer size: 0-1
               Queues:
                 - a (poll interval: 10.0s)


### PR DESCRIPTION
Inspired by some of @benhoskings's [commits on Ferocia's fork](https://github.com/ferocia/que/commits/master).

Startup now looks like:

```
➜ ./bin/que ./app.rb                                                                                                     
Que started worker process with:
  Worker threads: 6 (priorities: 10, 30, 50, any, any, any)
  Buffer size: 2-8
  Queues:
    - default (poll interval: 5s)
Que waiting for jobs...

➜ ./bin/que -w 9 -p 1,2,3,4,5,6,7 -i 1.2 -q a=10 -q b=20.05 -q c --minimum-buffer-size 0 --maximum-buffer-size 1 ./app.rb
Que started worker process with:
  Worker threads: 9 (priorities: 1, 2, 3, 4, 5, 6, 7, any, any)
  Buffer size: 0-1
  Queues:
    - a (poll interval: 10.0s)
    - b (poll interval: 20.05s)
    - c (poll interval: 1.2s)
Que waiting for jobs...
```