### PR TITLE
Support bulk enqueuing of jobs which differ only in args/kwargs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,8 @@
 
 ## 2.0.0 (2022-08-25)
 
+**Important: Do not upgrade straight to Que 2.** You will need to first update to the latest 1.x version, apply the Que database schema migration, and deploy, before you can safely begin the process of upgrading to Que 2. See the [2.0.0.beta1 changelog entry](#200beta1-2022-03-24) for details.
+
 See beta 2.0.0.beta1, plus:
 
 - **Fixed**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,20 @@
 - **Deprecated**:
     + Deprecated `que_state_notify` trigger (`que_state` notification channel / `job_change` notification message). See [#372](https://github.com/que-rb/que/issues/372). We plan to remove this in a future release - let us know on the issue if you desire otherwise.
 
+This release contains a database migration. You will need to migrate Que to the latest database schema version (7). For example, on ActiveRecord and Rails 6:
+
+```ruby
+class UpdateQueTablesToVersion6 < ActiveRecord::Migration[6.0]
+  def up
+    Que.migrate!(version: 7)
+  end
+
+  def down
+    Que.migrate!(version: 6)
+  end
+end
+```
+
 ## 2.0.0 (2022-08-25)
 
 **Important: Do not upgrade straight to Que 2.** You will need to first update to the latest 1.x version, apply the Que database schema migration, and deploy, before you can safely begin the process of upgrading to Que 2. See the [2.0.0.beta1 changelog entry](#200beta1-2022-03-24) for details.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 <!-- MarkdownTOC autolink=true -->
 
+- [Unreleased](#unreleased)
 - [2.0.0 \(2022-08-25\)](#200-2022-08-25)
 - [1.4.1 \(2022-07-24\)](#141-2022-07-24)
 - [2.0.0.beta1 \(2022-03-24\)](#200beta1-2022-03-24)
@@ -53,6 +54,13 @@
 - [0.0.1 \(2013-11-07\)](#001-2013-11-07)
 
 <!-- /MarkdownTOC -->
+
+## Unreleased
+
+- **Added**:
+    + Added bulk enqueue interface for performance when enqueuing a large number of jobs at once - [docs](docs#enqueueing-jobs-in-bulk).
+- **Deprecated**:
+    + Deprecated `que_state_notify` trigger (`que_state` notification channel / `job_change` notification message). See [#372](https://github.com/que-rb/que/issues/372). We plan to remove this in a future release - let us know on the issue if you desire otherwise.
 
 ## 2.0.0 (2022-08-25)
 

--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ group :test do
   gem 'minitest',         '~> 5.10.1'
   gem 'minitest-profile', '0.0.2'
   gem 'minitest-hooks',   '1.4.0'
+  gem 'minitest-fail-fast', '0.1.0'
 
   gem 'm'
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -853,6 +853,7 @@ The jobs are only actually enqueued at the end of the block, at which point they
 
 Limitations:
 
+- ActiveJob is not supported
 - All jobs must use the same job class
 - All jobs must use the same `job_options` (`job_options` must be provided to `.bulk_enqueue` instead of `.enqueue`)
 - The `que_attrs` of a job instance returned from `.enqueue` is empty (`{}`)

--- a/docs/README.md
+++ b/docs/README.md
@@ -874,8 +874,7 @@ If you prefer to leave finished jobs in the database for a while, to performantl
 
 ```sql
 BEGIN;
-ALTER TABLE que_jobs DISABLE TRIGGER que_state_notify;
+SET LOCAL que.skip_notify TO true;
 DELETE FROM que_jobs WHERE finished_at < (select now() - interval '7 days');
-ALTER TABLE que_jobs ENABLE TRIGGER que_state_notify;
 COMMIT;
 ```

--- a/lib/que.rb
+++ b/lib/que.rb
@@ -69,7 +69,7 @@ module Que
 
     # Copy some commonly-used methods here, for convenience.
     def_delegators :pool, :execute, :checkout, :in_transaction?
-    def_delegators Job, :enqueue, :run_synchronously, :run_synchronously=
+    def_delegators Job, :enqueue, :bulk_enqueue, :run_synchronously, :run_synchronously=
     def_delegators Migrations, :db_version, :migrate!
 
     # Global configuration logic.

--- a/lib/que/job.rb
+++ b/lib/que/job.rb
@@ -108,7 +108,7 @@ module Que
 
         if Thread.current[:que_jobs_to_bulk_insert]
           if self.name == 'ActiveJob::QueueAdapters::QueAdapter::JobWrapper'
-            raise Que::Error, "Que.bulk_enqueue does not support ActiveJob. Instead use: Que.enqueue(job_options: { job_class: 'MyJob' })"
+            raise Que::Error, "Que.bulk_enqueue does not support ActiveJob."
           end
 
           raise Que::Error, "When using .bulk_enqueue, job_options must be passed to that method rather than .enqueue" unless job_options == {}

--- a/lib/que/job.rb
+++ b/lib/que/job.rb
@@ -107,7 +107,12 @@ module Que
         }
 
         if Thread.current[:que_jobs_to_bulk_insert]
+          if self.name == 'ActiveJob::QueueAdapters::QueAdapter::JobWrapper'
+            raise Que::Error, "Que.bulk_enqueue does not support ActiveJob. Instead use: Que.enqueue(job_options: { job_class: 'MyJob' })"
+          end
+
           raise Que::Error, "When using .bulk_enqueue, job_options must be passed to that method rather than .enqueue" unless job_options == {}
+
           Thread.current[:que_jobs_to_bulk_insert][:jobs_attrs] << attrs
           new({})
         elsif attrs[:run_at].nil? && resolve_que_setting(:run_synchronously)

--- a/lib/que/job.rb
+++ b/lib/que/job.rb
@@ -120,7 +120,6 @@ module Que
               ).first
             else
               raise Que::Error, "When using .bulk_enqueue, job_options must be passed to that method rather than .enqueue" unless job_options == {}
-              Thread.current[:que_jobs_to_bulk_insert][:job_options]
               Thread.current[:que_jobs_to_bulk_insert][:jobs_attrs] << attrs
               {}
             end

--- a/lib/que/job.rb
+++ b/lib/que/job.rb
@@ -162,10 +162,13 @@ module Que
           _run_attrs(attrs)
         else
           values_array =
-            Que.execute(
-              :bulk_insert_jobs,
-              attrs.values_at(:queue, :priority, :run_at, :job_class, :args, :data),
-            )
+            Que.transaction do
+              Que.execute('SET LOCAL que.skip_notify TO true')
+              Que.execute(
+                :bulk_insert_jobs,
+                attrs.values_at(:queue, :priority, :run_at, :job_class, :args, :data),
+              )
+            end
           values_array.map(&method(:new))
         end
       end

--- a/lib/que/job.rb
+++ b/lib/que/job.rb
@@ -134,6 +134,7 @@ module Que
         yield
         jobs_attrs = Thread.current[:que_jobs_to_bulk_insert][:jobs_attrs]
         job_options = Thread.current[:que_jobs_to_bulk_insert][:job_options]
+        return [] if jobs_attrs.empty?
         raise Que::Error, "When using .bulk_enqueue, all jobs enqueued must be of the same job class" unless jobs_attrs.map { |attrs| attrs[:job_class] }.uniq.one?
         args_and_kwargs_array = jobs_attrs.map do |attrs|
           {

--- a/lib/que/job.rb
+++ b/lib/que/job.rb
@@ -137,6 +137,13 @@ module Que
           end
         end
 
+        args_and_kwargs_array = args_and_kwargs_array.map do |args_and_kwargs|
+          args_and_kwargs.merge(
+            args: args_and_kwargs.fetch(:args, []),
+            kwargs: args_and_kwargs.fetch(:kwargs, {}),
+          )
+        end
+
         attrs = {
           queue:    job_options[:queue]    || resolve_que_setting(:queue) || Que.default_queue,
           priority: job_options[:priority] || resolve_que_setting(:priority),

--- a/lib/que/migrations.rb
+++ b/lib/que/migrations.rb
@@ -4,7 +4,7 @@ module Que
   module Migrations
     # In order to ship a schema change, add the relevant up and down sql files
     # to the migrations directory, and bump the version here.
-    CURRENT_VERSION = 6
+    CURRENT_VERSION = 7
 
     class << self
       def migrate!(version:)

--- a/lib/que/migrations/7/down.sql
+++ b/lib/que/migrations/7/down.sql
@@ -1,0 +1,5 @@
+DROP TRIGGER que_job_notify ON que_jobs;
+CREATE TRIGGER que_job_notify
+  AFTER INSERT ON que_jobs
+  FOR EACH ROW
+  EXECUTE PROCEDURE public.que_job_notify();

--- a/lib/que/migrations/7/up.sql
+++ b/lib/que/migrations/7/up.sql
@@ -1,0 +1,6 @@
+DROP TRIGGER que_job_notify ON que_jobs;
+CREATE TRIGGER que_job_notify
+  AFTER INSERT ON que_jobs
+  FOR EACH ROW
+  WHEN (NOT coalesce(current_setting('que.skip_notify', true), '') = 'true')
+  EXECUTE FUNCTION public.que_job_notify();

--- a/lib/que/migrations/7/up.sql
+++ b/lib/que/migrations/7/up.sql
@@ -4,3 +4,10 @@ CREATE TRIGGER que_job_notify
   FOR EACH ROW
   WHEN (NOT coalesce(current_setting('que.skip_notify', true), '') = 'true')
   EXECUTE PROCEDURE public.que_job_notify();
+
+DROP TRIGGER que_state_notify ON que_jobs;
+CREATE TRIGGER que_state_notify
+  AFTER INSERT OR UPDATE OR DELETE ON que_jobs
+  FOR EACH ROW
+  WHEN (NOT coalesce(current_setting('que.skip_notify', true), '') = 'true')
+  EXECUTE PROCEDURE public.que_state_notify();

--- a/lib/que/migrations/7/up.sql
+++ b/lib/que/migrations/7/up.sql
@@ -3,4 +3,4 @@ CREATE TRIGGER que_job_notify
   AFTER INSERT ON que_jobs
   FOR EACH ROW
   WHEN (NOT coalesce(current_setting('que.skip_notify', true), '') = 'true')
-  EXECUTE FUNCTION public.que_job_notify();
+  EXECUTE PROCEDURE public.que_job_notify();

--- a/scripts/test
+++ b/scripts/test
@@ -3,3 +3,4 @@
 set -Eeuo pipefail
 
 bundle exec rake spec "$@"
+USE_RAILS=true bundle exec rake spec "$@"

--- a/spec/que/active_job/extensions_spec.rb
+++ b/spec/que/active_job/extensions_spec.rb
@@ -16,6 +16,7 @@ if defined?(::ActiveJob)
     after do
       Object.send :remove_const, :TestJobClass
       $args = nil
+      $kwargs = nil
     end
 
     def execute(&perform_later_block)
@@ -169,6 +170,30 @@ if defined?(::ActiveJob)
         end
         assert_equal "Oopsie!", error.message
         assert_equal error, notified_error
+      end
+    end
+
+    describe 'with bulk_enqueue' do
+      describe 'ActiveJobClass.perform_later' do
+        it "is not supported" do
+          assert_raises_with_message(
+            Que::Error,
+            /Que\.bulk_enqueue does not support ActiveJob\./
+          ) do
+            Que.bulk_enqueue { TestJobClass.perform_later(1, 2) }
+          end
+        end
+      end
+
+      describe 'active_job#enqueue' do
+        it "is not supported" do
+          assert_raises_with_message(
+            Que::Error,
+            /Que\.bulk_enqueue does not support ActiveJob\./
+          ) do
+            Que.bulk_enqueue { TestJobClass.new.enqueue }
+          end
+        end
       end
     end
   end

--- a/spec/que/job.bulk_enqueue_spec.rb
+++ b/spec/que/job.bulk_enqueue_spec.rb
@@ -1,0 +1,383 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Que::Job, '.bulk_enqueue' do
+  def assert_enqueue(
+    expected_queue: 'default',
+    expected_priority: 100,
+    expected_run_at: Time.now,
+    expected_job_class: Que::Job,
+    expected_result_class: nil,
+    expected_args:,
+    expected_kwargs:,
+    expected_tags: nil,
+    expected_count:,
+    &enqueue_block
+  )
+
+    assert_equal 0, jobs_dataset.count
+
+    results = enqueue_block.call
+
+    assert_equal expected_count, jobs_dataset.count
+
+    results.each_with_index do |result, i|
+      assert_kind_of Que::Job, result
+      assert_instance_of (expected_result_class || expected_job_class), result
+
+      assert_equal expected_priority, result.que_attrs[:priority]
+      assert_equal expected_args[i], result.que_attrs[:args]
+      assert_equal expected_kwargs[i], result.que_attrs[:kwargs]
+
+      if expected_tags.nil?
+        assert_equal({}, result.que_attrs[:data])
+      else
+        assert_equal expected_tags, result.que_attrs[:data][:tags]
+      end
+    end
+
+    job = jobs_dataset.each_with_index do |job, i|
+      assert_equal expected_queue, job[:queue]
+      assert_equal expected_priority, job[:priority]
+      assert_in_delta job[:run_at], expected_run_at, QueSpec::TIME_SKEW
+      assert_equal expected_job_class.to_s, job[:job_class]
+      assert_equal expected_args[i], job[:args]
+      assert_equal expected_kwargs[i], job[:kwargs]
+    end
+
+    jobs_dataset.delete
+  end
+
+  it "should be able to queue multiple jobs" do
+    assert_enqueue(
+      expected_count: 3,
+      expected_args: Array.new(3) { [] },
+      expected_kwargs: Array.new(3) { {} },
+    ) do
+      Que.bulk_enqueue(
+        Array.new(3) { { args: [], kwargs: {} } }
+      )
+    end
+  end
+
+  it "should be able to queue multiple jobs with arguments" do
+    assert_enqueue(
+      expected_count: 3,
+      expected_args: [[1, 'two'], ['3', 4], [5, 6]],
+      expected_kwargs: [{ seven: '8' }, { '9': 10 }, { eleven: 'twelve' }],
+    ) do
+      Que.bulk_enqueue(
+        [
+          { args: [1, 'two'], kwargs: { seven: '8' } },
+          { args: ['3', 4], kwargs: { '9' => 10 } },
+          { args: [5, 6], kwargs: { 'eleven' => 'twelve' } },
+        ]
+      )
+    end
+  end
+
+  # it "should be able to queue a job with complex arguments" do
+  #   assert_enqueue(
+  #     expected_args: [
+  #       1,
+  #       'two',
+  #     ],
+  #     expected_kwargs: {
+  #       string: "string",
+  #       integer: 5,
+  #       array: [1, "two", {three: 3}],
+  #       hash: {one: 1, two: 'two', three: [3]},
+  #     },
+  #   ) do
+  #     Que.enqueue(
+  #       1,
+  #       'two',
+  #       string: "string",
+  #       integer: 5,
+  #       array: [1, "two", {three: 3}],
+  #       hash: {one: 1, two: 'two', three: [3]},
+  #     )
+  #   end
+  # end
+  #
+  # it "should be able to handle a namespaced job class" do
+  #   assert_enqueue(
+  #     expected_args: [1],
+  #     expected_job_class: NamespacedJobNamespace::NamespacedJob,
+  #   ) { NamespacedJobNamespace::NamespacedJob.enqueue(1) }
+  # end
+  #
+  # it "should error appropriately on an anonymous job subclass" do
+  #   klass = Class.new(Que::Job)
+  #
+  #   error = assert_raises(Que::Error) { klass.enqueue(1) }
+  #
+  #   assert_equal \
+  #     "Can't enqueue an anonymous subclass of Que::Job",
+  #     error.message
+  # end
+  #
+  # it "should be able to queue a job with a specific queue name" do
+  #   assert_enqueue(
+  #     expected_args: [1],
+  #     expected_queue: 'special_queue_name',
+  #   ) { Que.enqueue(1, job_options: { queue: 'special_queue_name' }) }
+  # end
+  #
+  # it "should be able to queue a job with a specific time to run" do
+  #   assert_enqueue(
+  #     expected_args: [1],
+  #     expected_run_at: Time.now + 60,
+  #   ) { Que.enqueue(1, job_options: { run_at: Time.now + 60 }) }
+  # end
+  #
+  # it "should be able to queue a job with a specific priority" do
+  #   assert_enqueue(
+  #     expected_args: [1],
+  #     expected_priority: 4,
+  #   ) { Que.enqueue(1, job_options: { priority: 4 }) }
+  # end
+  #
+  # it "should be able to queue a job with options in addition to args and kwargs" do
+  #   assert_enqueue(
+  #     expected_args: [1],
+  #     expected_kwargs: { string: "string" },
+  #     expected_run_at: Time.now + 60,
+  #     expected_priority: 4,
+  #   ) { Que.enqueue(1, string: "string", job_options: { run_at: Time.now + 60, priority: 4 }) }
+  # end
+  #
+  # it "should no longer fall back to using job options specified at the top level if not specified in job_options" do
+  #   assert_enqueue(
+  #     expected_args: [1],
+  #     expected_kwargs: { string: "string", run_at: Time.utc(2050).to_s, priority: 10 },
+  #     expected_run_at: Time.now,
+  #     expected_priority: 15,
+  #   ) { Que.enqueue(1, string: "string", run_at: Time.utc(2050), priority: 10, job_options: { priority: 15 }) }
+  # end
+  #
+  # describe "when enqueuing a job with tags" do
+  #   it "should be able to specify tags on a case-by-case basis" do
+  #     assert_enqueue(
+  #       expected_args: [1],
+  #       expected_kwargs: { string: "string" },
+  #       expected_tags: ["tag_1", "tag_2"],
+  #     ) { Que.enqueue(1, string: "string", job_options: { tags: ["tag_1", "tag_2"] }) }
+  #   end
+  #
+  #   it "should no longer fall back to using tags specified at the top level if not specified in job_options" do
+  #     assert_enqueue(
+  #       expected_args: [1],
+  #       expected_kwargs: { string: "string", tags: ["tag_1", "tag_2"] },
+  #       expected_tags: nil,
+  #     ) { Que.enqueue(1, string: "string", tags: ["tag_1", "tag_2"]) }
+  #   end
+  #
+  #   it "should raise an error if passing too many tags" do
+  #     error =
+  #       assert_raises(Que::Error) do
+  #         Que::Job.enqueue 1, string: "string", job_options: { tags: %w[a b c d e f] }
+  #       end
+  #
+  #     assert_equal \
+  #       "Can't enqueue a job with more than 5 tags! (passed 6)",
+  #       error.message
+  #   end
+  #
+  #   it "should raise an error if any of the tags are too long" do
+  #     error =
+  #       assert_raises(Que::Error) do
+  #         Que::Job.enqueue 1, string: "string", job_options: { tags: ["a" * 101] }
+  #       end
+  #
+  #     assert_equal \
+  #       "Can't enqueue a job with a tag longer than 100 characters! (\"#{"a" * 101}\")",
+  #       error.message
+  #   end
+  # end
+  #
+  # it "should respect a job class defined as a string" do
+  #   class MyJobClass < Que::Job; end
+  #
+  #   assert_enqueue(
+  #     expected_args: ['argument'],
+  #     expected_kwargs: { other_arg: "other_arg" },
+  #     expected_job_class: MyJobClass,
+  #     expected_result_class: Que::Job
+  #   ) { Que.enqueue('argument', other_arg: "other_arg", job_options: { job_class: 'MyJobClass' }) }
+  # end
+  #
+  # describe "when there's a hierarchy of job classes" do
+  #   class PriorityDefaultJob < Que::Job
+  #     self.priority = 3
+  #   end
+  #
+  #   class PrioritySubclassJob < PriorityDefaultJob
+  #   end
+  #
+  #   class RunAtDefaultJob < Que::Job
+  #     self.run_at = -> { Time.now + 30 }
+  #   end
+  #
+  #   class RunAtSubclassJob < RunAtDefaultJob
+  #   end
+  #
+  #   class QueueDefaultJob < Que::Job
+  #     self.queue = :queue_1
+  #   end
+  #
+  #   class QueueSubclassJob < QueueDefaultJob
+  #   end
+  #
+  #   describe "priority" do
+  #     it "should respect a default priority in a job class" do
+  #       assert_enqueue(
+  #         expected_args: [1],
+  #         expected_priority: 3,
+  #         expected_job_class: PriorityDefaultJob
+  #       ) { PriorityDefaultJob.enqueue(1) }
+  #
+  #       assert_enqueue(
+  #         expected_args: [1],
+  #         expected_priority: 4,
+  #         expected_job_class: PriorityDefaultJob
+  #       ) { PriorityDefaultJob.enqueue(1, job_options: { priority: 4 }) }
+  #     end
+  #
+  #     it "should respect an inherited priority in a job class" do
+  #       assert_enqueue(
+  #         expected_args: [1],
+  #         expected_priority: 3,
+  #         expected_job_class: PrioritySubclassJob
+  #       ) { PrioritySubclassJob.enqueue(1) }
+  #
+  #       assert_enqueue(
+  #         expected_args: [1],
+  #         expected_priority: 4,
+  #         expected_job_class: PrioritySubclassJob
+  #       ) { PrioritySubclassJob.enqueue(1, job_options: { priority: 4 }) }
+  #     end
+  #
+  #     it "should respect an overridden priority in a job class" do
+  #       begin
+  #         PrioritySubclassJob.priority = 60
+  #
+  #         assert_enqueue(
+  #           expected_args: [1],
+  #           expected_priority: 60,
+  #           expected_job_class: PrioritySubclassJob
+  #         ) { PrioritySubclassJob.enqueue(1) }
+  #
+  #         assert_enqueue(
+  #           expected_args: [1],
+  #           expected_priority: 4,
+  #           expected_job_class: PrioritySubclassJob
+  #         ) { PrioritySubclassJob.enqueue(1, job_options: { priority: 4 }) }
+  #       ensure
+  #         PrioritySubclassJob.remove_instance_variable(:@priority)
+  #       end
+  #     end
+  #   end
+  #
+  #   describe "run_at" do
+  #     it "should respect a default run_at in a job class" do
+  #       assert_enqueue(
+  #         expected_args: [1],
+  #         expected_run_at: Time.now + 30,
+  #         expected_job_class: RunAtDefaultJob
+  #       ) { RunAtDefaultJob.enqueue(1) }
+  #
+  #       assert_enqueue(
+  #         expected_args: [1],
+  #         expected_run_at: Time.now + 60,
+  #         expected_job_class: RunAtDefaultJob
+  #       ) { RunAtDefaultJob.enqueue(1, job_options: { run_at: Time.now + 60 }) }
+  #     end
+  #
+  #     it "should respect an inherited run_at in a job class" do
+  #       assert_enqueue(
+  #         expected_args: [1],
+  #         expected_run_at: Time.now + 30,
+  #         expected_job_class: RunAtSubclassJob
+  #       ) { RunAtSubclassJob.enqueue(1) }
+  #
+  #       assert_enqueue(
+  #         expected_args: [1],
+  #         expected_run_at: Time.now + 60,
+  #         expected_job_class: RunAtSubclassJob
+  #       ) { RunAtSubclassJob.enqueue(1, job_options: { run_at: Time.now + 60 }) }
+  #     end
+  #
+  #     it "should respect an overridden run_at in a job class" do
+  #       begin
+  #         RunAtSubclassJob.run_at = -> {Time.now + 90}
+  #
+  #         assert_enqueue(
+  #           expected_args: [1],
+  #           expected_run_at: Time.now + 90,
+  #           expected_job_class: RunAtSubclassJob
+  #         ) { RunAtSubclassJob.enqueue(1) }
+  #
+  #         assert_enqueue(
+  #           expected_args: [1],
+  #           expected_run_at: Time.now + 60,
+  #           expected_job_class: RunAtSubclassJob
+  #         ) { RunAtSubclassJob.enqueue(1, job_options: { run_at: Time.now + 60 }) }
+  #       ensure
+  #         RunAtSubclassJob.remove_instance_variable(:@run_at)
+  #       end
+  #     end
+  #   end
+  #
+  #   describe "queue" do
+  #     it "should respect a default queue in a job class" do
+  #       assert_enqueue(
+  #         expected_args: [1],
+  #         expected_queue: 'queue_1',
+  #         expected_job_class: QueueDefaultJob
+  #       ) { QueueDefaultJob.enqueue(1) }
+  #
+  #       assert_enqueue(
+  #         expected_args: [1],
+  #         expected_queue: 'queue_3',
+  #         expected_job_class: QueueDefaultJob
+  #       ) { QueueDefaultJob.enqueue(1, job_options: { queue: 'queue_3' }) }
+  #     end
+  #
+  #     it "should respect an inherited queue in a job class" do
+  #       assert_enqueue(
+  #         expected_args: [1],
+  #         expected_queue: 'queue_1',
+  #         expected_job_class: QueueSubclassJob
+  #       ) { QueueSubclassJob.enqueue(1) }
+  #
+  #       assert_enqueue(
+  #         expected_args: [1],
+  #         expected_queue: 'queue_3',
+  #         expected_job_class: QueueSubclassJob
+  #       ) { QueueSubclassJob.enqueue(1, job_options: { queue: 'queue_3' }) }
+  #     end
+  #
+  #     it "should respect an overridden queue in a job class" do
+  #       begin
+  #         QueueSubclassJob.queue = :queue_2
+  #
+  #         assert_enqueue(
+  #           expected_args: [1],
+  #           expected_queue: 'queue_2',
+  #           expected_job_class: QueueSubclassJob
+  #         ) { QueueSubclassJob.enqueue(1) }
+  #
+  #         assert_enqueue(
+  #           expected_args: [1],
+  #           expected_queue: 'queue_3',
+  #           expected_job_class: QueueSubclassJob
+  #         ) { QueueSubclassJob.enqueue(1, job_options: { queue: 'queue_3' }) }
+  #       ensure
+  #         QueueSubclassJob.remove_instance_variable(:@queue)
+  #       end
+  #     end
+  #   end
+  # end
+end

--- a/spec/que/job.bulk_enqueue_spec.rb
+++ b/spec/que/job.bulk_enqueue_spec.rb
@@ -37,7 +37,7 @@ describe Que::Job, '.bulk_enqueue' do
       end
     end
 
-    job = jobs_dataset.each_with_index do |job, i|
+    jobs_dataset.each_with_index do |job, i|
       assert_equal expected_queue, job[:queue]
       assert_equal expected_priority, job[:priority]
       assert_in_delta job[:run_at], expected_run_at, QueSpec::TIME_SKEW
@@ -63,321 +63,579 @@ describe Que::Job, '.bulk_enqueue' do
 
   it "should be able to queue multiple jobs with arguments" do
     assert_enqueue(
-      expected_count: 3,
-      expected_args: [[1, 'two'], ['3', 4], [5, 6]],
-      expected_kwargs: [{ seven: '8' }, { '9': 10 }, { eleven: 'twelve' }],
+      expected_count: 2,
+      expected_args: [[1], [4]],
+      expected_kwargs: [{ two: '3' }, { five: '6' }],
     ) do
       Que.bulk_enqueue(
         [
-          { args: [1, 'two'], kwargs: { seven: '8' } },
-          { args: ['3', 4], kwargs: { '9' => 10 } },
-          { args: [5, 6], kwargs: { 'eleven' => 'twelve' } },
+          { args: [1], kwargs: { two: '3' } },
+          { args: [4], kwargs: { five: '6' } },
         ]
       )
     end
   end
 
-  # it "should be able to queue a job with complex arguments" do
-  #   assert_enqueue(
-  #     expected_args: [
-  #       1,
-  #       'two',
-  #     ],
-  #     expected_kwargs: {
-  #       string: "string",
-  #       integer: 5,
-  #       array: [1, "two", {three: 3}],
-  #       hash: {one: 1, two: 'two', three: [3]},
-  #     },
-  #   ) do
-  #     Que.enqueue(
-  #       1,
-  #       'two',
-  #       string: "string",
-  #       integer: 5,
-  #       array: [1, "two", {three: 3}],
-  #       hash: {one: 1, two: 'two', three: [3]},
-  #     )
-  #   end
-  # end
-  #
-  # it "should be able to handle a namespaced job class" do
-  #   assert_enqueue(
-  #     expected_args: [1],
-  #     expected_job_class: NamespacedJobNamespace::NamespacedJob,
-  #   ) { NamespacedJobNamespace::NamespacedJob.enqueue(1) }
-  # end
-  #
-  # it "should error appropriately on an anonymous job subclass" do
-  #   klass = Class.new(Que::Job)
-  #
-  #   error = assert_raises(Que::Error) { klass.enqueue(1) }
-  #
-  #   assert_equal \
-  #     "Can't enqueue an anonymous subclass of Que::Job",
-  #     error.message
-  # end
-  #
-  # it "should be able to queue a job with a specific queue name" do
-  #   assert_enqueue(
-  #     expected_args: [1],
-  #     expected_queue: 'special_queue_name',
-  #   ) { Que.enqueue(1, job_options: { queue: 'special_queue_name' }) }
-  # end
-  #
-  # it "should be able to queue a job with a specific time to run" do
-  #   assert_enqueue(
-  #     expected_args: [1],
-  #     expected_run_at: Time.now + 60,
-  #   ) { Que.enqueue(1, job_options: { run_at: Time.now + 60 }) }
-  # end
-  #
-  # it "should be able to queue a job with a specific priority" do
-  #   assert_enqueue(
-  #     expected_args: [1],
-  #     expected_priority: 4,
-  #   ) { Que.enqueue(1, job_options: { priority: 4 }) }
-  # end
-  #
-  # it "should be able to queue a job with options in addition to args and kwargs" do
-  #   assert_enqueue(
-  #     expected_args: [1],
-  #     expected_kwargs: { string: "string" },
-  #     expected_run_at: Time.now + 60,
-  #     expected_priority: 4,
-  #   ) { Que.enqueue(1, string: "string", job_options: { run_at: Time.now + 60, priority: 4 }) }
-  # end
-  #
-  # it "should no longer fall back to using job options specified at the top level if not specified in job_options" do
-  #   assert_enqueue(
-  #     expected_args: [1],
-  #     expected_kwargs: { string: "string", run_at: Time.utc(2050).to_s, priority: 10 },
-  #     expected_run_at: Time.now,
-  #     expected_priority: 15,
-  #   ) { Que.enqueue(1, string: "string", run_at: Time.utc(2050), priority: 10, job_options: { priority: 15 }) }
-  # end
-  #
-  # describe "when enqueuing a job with tags" do
-  #   it "should be able to specify tags on a case-by-case basis" do
-  #     assert_enqueue(
-  #       expected_args: [1],
-  #       expected_kwargs: { string: "string" },
-  #       expected_tags: ["tag_1", "tag_2"],
-  #     ) { Que.enqueue(1, string: "string", job_options: { tags: ["tag_1", "tag_2"] }) }
-  #   end
-  #
-  #   it "should no longer fall back to using tags specified at the top level if not specified in job_options" do
-  #     assert_enqueue(
-  #       expected_args: [1],
-  #       expected_kwargs: { string: "string", tags: ["tag_1", "tag_2"] },
-  #       expected_tags: nil,
-  #     ) { Que.enqueue(1, string: "string", tags: ["tag_1", "tag_2"]) }
-  #   end
-  #
-  #   it "should raise an error if passing too many tags" do
-  #     error =
-  #       assert_raises(Que::Error) do
-  #         Que::Job.enqueue 1, string: "string", job_options: { tags: %w[a b c d e f] }
-  #       end
-  #
-  #     assert_equal \
-  #       "Can't enqueue a job with more than 5 tags! (passed 6)",
-  #       error.message
-  #   end
-  #
-  #   it "should raise an error if any of the tags are too long" do
-  #     error =
-  #       assert_raises(Que::Error) do
-  #         Que::Job.enqueue 1, string: "string", job_options: { tags: ["a" * 101] }
-  #       end
-  #
-  #     assert_equal \
-  #       "Can't enqueue a job with a tag longer than 100 characters! (\"#{"a" * 101}\")",
-  #       error.message
-  #   end
-  # end
-  #
-  # it "should respect a job class defined as a string" do
-  #   class MyJobClass < Que::Job; end
-  #
-  #   assert_enqueue(
-  #     expected_args: ['argument'],
-  #     expected_kwargs: { other_arg: "other_arg" },
-  #     expected_job_class: MyJobClass,
-  #     expected_result_class: Que::Job
-  #   ) { Que.enqueue('argument', other_arg: "other_arg", job_options: { job_class: 'MyJobClass' }) }
-  # end
-  #
-  # describe "when there's a hierarchy of job classes" do
-  #   class PriorityDefaultJob < Que::Job
-  #     self.priority = 3
-  #   end
-  #
-  #   class PrioritySubclassJob < PriorityDefaultJob
-  #   end
-  #
-  #   class RunAtDefaultJob < Que::Job
-  #     self.run_at = -> { Time.now + 30 }
-  #   end
-  #
-  #   class RunAtSubclassJob < RunAtDefaultJob
-  #   end
-  #
-  #   class QueueDefaultJob < Que::Job
-  #     self.queue = :queue_1
-  #   end
-  #
-  #   class QueueSubclassJob < QueueDefaultJob
-  #   end
-  #
-  #   describe "priority" do
-  #     it "should respect a default priority in a job class" do
-  #       assert_enqueue(
-  #         expected_args: [1],
-  #         expected_priority: 3,
-  #         expected_job_class: PriorityDefaultJob
-  #       ) { PriorityDefaultJob.enqueue(1) }
-  #
-  #       assert_enqueue(
-  #         expected_args: [1],
-  #         expected_priority: 4,
-  #         expected_job_class: PriorityDefaultJob
-  #       ) { PriorityDefaultJob.enqueue(1, job_options: { priority: 4 }) }
-  #     end
-  #
-  #     it "should respect an inherited priority in a job class" do
-  #       assert_enqueue(
-  #         expected_args: [1],
-  #         expected_priority: 3,
-  #         expected_job_class: PrioritySubclassJob
-  #       ) { PrioritySubclassJob.enqueue(1) }
-  #
-  #       assert_enqueue(
-  #         expected_args: [1],
-  #         expected_priority: 4,
-  #         expected_job_class: PrioritySubclassJob
-  #       ) { PrioritySubclassJob.enqueue(1, job_options: { priority: 4 }) }
-  #     end
-  #
-  #     it "should respect an overridden priority in a job class" do
-  #       begin
-  #         PrioritySubclassJob.priority = 60
-  #
-  #         assert_enqueue(
-  #           expected_args: [1],
-  #           expected_priority: 60,
-  #           expected_job_class: PrioritySubclassJob
-  #         ) { PrioritySubclassJob.enqueue(1) }
-  #
-  #         assert_enqueue(
-  #           expected_args: [1],
-  #           expected_priority: 4,
-  #           expected_job_class: PrioritySubclassJob
-  #         ) { PrioritySubclassJob.enqueue(1, job_options: { priority: 4 }) }
-  #       ensure
-  #         PrioritySubclassJob.remove_instance_variable(:@priority)
-  #       end
-  #     end
-  #   end
-  #
-  #   describe "run_at" do
-  #     it "should respect a default run_at in a job class" do
-  #       assert_enqueue(
-  #         expected_args: [1],
-  #         expected_run_at: Time.now + 30,
-  #         expected_job_class: RunAtDefaultJob
-  #       ) { RunAtDefaultJob.enqueue(1) }
-  #
-  #       assert_enqueue(
-  #         expected_args: [1],
-  #         expected_run_at: Time.now + 60,
-  #         expected_job_class: RunAtDefaultJob
-  #       ) { RunAtDefaultJob.enqueue(1, job_options: { run_at: Time.now + 60 }) }
-  #     end
-  #
-  #     it "should respect an inherited run_at in a job class" do
-  #       assert_enqueue(
-  #         expected_args: [1],
-  #         expected_run_at: Time.now + 30,
-  #         expected_job_class: RunAtSubclassJob
-  #       ) { RunAtSubclassJob.enqueue(1) }
-  #
-  #       assert_enqueue(
-  #         expected_args: [1],
-  #         expected_run_at: Time.now + 60,
-  #         expected_job_class: RunAtSubclassJob
-  #       ) { RunAtSubclassJob.enqueue(1, job_options: { run_at: Time.now + 60 }) }
-  #     end
-  #
-  #     it "should respect an overridden run_at in a job class" do
-  #       begin
-  #         RunAtSubclassJob.run_at = -> {Time.now + 90}
-  #
-  #         assert_enqueue(
-  #           expected_args: [1],
-  #           expected_run_at: Time.now + 90,
-  #           expected_job_class: RunAtSubclassJob
-  #         ) { RunAtSubclassJob.enqueue(1) }
-  #
-  #         assert_enqueue(
-  #           expected_args: [1],
-  #           expected_run_at: Time.now + 60,
-  #           expected_job_class: RunAtSubclassJob
-  #         ) { RunAtSubclassJob.enqueue(1, job_options: { run_at: Time.now + 60 }) }
-  #       ensure
-  #         RunAtSubclassJob.remove_instance_variable(:@run_at)
-  #       end
-  #     end
-  #   end
-  #
-  #   describe "queue" do
-  #     it "should respect a default queue in a job class" do
-  #       assert_enqueue(
-  #         expected_args: [1],
-  #         expected_queue: 'queue_1',
-  #         expected_job_class: QueueDefaultJob
-  #       ) { QueueDefaultJob.enqueue(1) }
-  #
-  #       assert_enqueue(
-  #         expected_args: [1],
-  #         expected_queue: 'queue_3',
-  #         expected_job_class: QueueDefaultJob
-  #       ) { QueueDefaultJob.enqueue(1, job_options: { queue: 'queue_3' }) }
-  #     end
-  #
-  #     it "should respect an inherited queue in a job class" do
-  #       assert_enqueue(
-  #         expected_args: [1],
-  #         expected_queue: 'queue_1',
-  #         expected_job_class: QueueSubclassJob
-  #       ) { QueueSubclassJob.enqueue(1) }
-  #
-  #       assert_enqueue(
-  #         expected_args: [1],
-  #         expected_queue: 'queue_3',
-  #         expected_job_class: QueueSubclassJob
-  #       ) { QueueSubclassJob.enqueue(1, job_options: { queue: 'queue_3' }) }
-  #     end
-  #
-  #     it "should respect an overridden queue in a job class" do
-  #       begin
-  #         QueueSubclassJob.queue = :queue_2
-  #
-  #         assert_enqueue(
-  #           expected_args: [1],
-  #           expected_queue: 'queue_2',
-  #           expected_job_class: QueueSubclassJob
-  #         ) { QueueSubclassJob.enqueue(1) }
-  #
-  #         assert_enqueue(
-  #           expected_args: [1],
-  #           expected_queue: 'queue_3',
-  #           expected_job_class: QueueSubclassJob
-  #         ) { QueueSubclassJob.enqueue(1, job_options: { queue: 'queue_3' }) }
-  #       ensure
-  #         QueueSubclassJob.remove_instance_variable(:@queue)
-  #       end
-  #     end
-  #   end
-  # end
+  it "should be able to queue jobs with complex arguments" do
+    assert_enqueue(
+      expected_count: 2,
+      expected_args: [[1, 'two'], ['3', 4]],
+      expected_kwargs: [
+        { string: 'string', integer: 5, array: [1, 'two', { three: 3 }] },
+        { hash: { one: 1, two: 'two', three: [3] } },
+      ],
+    ) do
+      Que.bulk_enqueue(
+        [
+          { args: [1, 'two'], kwargs: { string: 'string', integer: 5, array: [1, 'two', { three: 3 }] } },
+          { args: ['3', 4], kwargs: { hash: { one: 1, two: 'two', three: [3] } } },
+        ],
+      )
+    end
+  end
+
+  it "should be able to handle a namespaced job class" do
+    assert_enqueue(
+      expected_count: 2,
+      expected_args: [[1], [4]],
+      expected_kwargs: [{ two: '3' }, { five: '6' }],
+      expected_job_class: NamespacedJobNamespace::NamespacedJob,
+    ) do
+      NamespacedJobNamespace::NamespacedJob.bulk_enqueue(
+        [
+          { args: [1], kwargs: { two: '3' } },
+          { args: [4], kwargs: { five: '6' } },
+        ],
+      )
+    end
+  end
+
+  it "should error appropriately on an anonymous job subclass" do
+    klass = Class.new(Que::Job)
+    error = assert_raises(Que::Error) { klass.bulk_enqueue([{ args: [], kwargs: {} }, { args: [], kwargs: {} }]) }
+    assert_equal \
+      "Can't enqueue an anonymous subclass of Que::Job",
+      error.message
+  end
+
+  it "should be able to queue jobs with specific queue names" do
+    assert_enqueue(
+      expected_count: 2,
+      expected_args: [[1], [4]],
+      expected_kwargs: [{ two: '3' }, { five: 'six' }],
+      expected_queue: 'special_queue_name',
+    ) do
+      Que.bulk_enqueue(
+        [
+          { args: [1], kwargs: { two: '3' } },
+          { args: [4], kwargs: { five: 'six' } }
+        ],
+        job_options: { queue: 'special_queue_name' },
+      )
+    end
+  end
+
+
+  it "should be able to queue jobs with a specific time to run" do
+    assert_enqueue(
+      expected_count: 2,
+      expected_args: [[1], [2]],
+      expected_kwargs: [{}, {}],
+      expected_run_at: Time.now + 60
+    ) do
+      Que.bulk_enqueue(
+        [{ args: [1], kwargs: {} }, { args: [2], kwargs: {} }],
+        job_options: { run_at: Time.now + 60 },
+      )
+    end
+  end
+
+  it "should be able to enqueue jobs with a specific priority" do
+    assert_enqueue(
+      expected_count: 2,
+      expected_args: [[1], [2]],
+      expected_kwargs: [{}, {}],
+      expected_priority: 4
+    ) do
+      Que.bulk_enqueue(
+        [{ args: [1], kwargs: {} }, { args: [2], kwargs: {} }],
+        job_options: { priority: 4 },
+      )
+    end
+  end
+
+  it "should be able to queue jobs with options in addition to args and kwargs" do
+    assert_enqueue(
+      expected_count: 2,
+      expected_args: [[1], [4]],
+      expected_kwargs: [{ two: "3" }, { five: "six" }],
+      expected_run_at: Time.now + 60,
+      expected_priority: 4,
+    ) do
+      Que.bulk_enqueue(
+        [
+          { args: [1], kwargs: { two: "3" } },
+          { args: [4], kwargs: { five: "six" } },
+        ],
+        job_options: { run_at: Time.now + 60, priority: 4 },
+      )
+    end
+  end
+
+  it "should no longer fall back to using job options specified at the top level if not specified in job_options" do
+    assert_enqueue(
+      expected_count: 2,
+      expected_args: [[1], [4]],
+      expected_kwargs: [
+        { two: "3", run_at: Time.utc(2050).to_s, priority: 10 },
+        { five: "six" }
+      ],
+      expected_run_at: Time.now,
+      expected_priority: 15,
+    ) do
+      Que.bulk_enqueue(
+        [
+          { args: [1], kwargs: { two: "3", run_at: Time.utc(2050), priority: 10 } },
+          { args: [4], kwargs: { five: "six" } },
+        ],
+        job_options: { priority: 15 },
+      )
+    end
+  end
+
+  describe "when enqueuing jobs with tags" do
+    it "should be able to specify tags on a case-by-case basis" do
+      assert_enqueue(
+        expected_count: 2,
+        expected_args: [[1], [4]],
+        expected_kwargs: [{ two: "3" }, { five: "six" }],
+        expected_tags: ["tag_1", "tag_2"],
+      ) do
+        Que.bulk_enqueue(
+          [
+            { args: [1], kwargs: { two: "3" } },
+            { args: [4], kwargs: { five: "six" } },
+          ],
+          job_options: { tags: ["tag_1", "tag_2"] },
+        )
+      end
+    end
+
+    it "should no longer fall back to using tags specified at the top level if not specified in job_options" do
+      assert_enqueue(
+        expected_count: 2,
+        expected_args: [[1], [4]],
+        expected_kwargs: [
+          { two: "3", tags: ["tag_1", "tag_2"] },
+          { five: "six" },
+        ],
+        expected_tags: nil,
+      ) do
+        Que.bulk_enqueue(
+          [
+            { args: [1], kwargs: { two: "3", tags: ["tag_1", "tag_2"] } },
+            { args: [4], kwargs: { five: "six" } },
+          ],
+        )
+      end
+    end
+
+    it "should raise an error if passing too many tags" do
+      error =
+        assert_raises(Que::Error) do
+          Que::Job.bulk_enqueue(
+            [
+              { args: [1], kwargs: { two: "3" } },
+              { args: [4], kwargs: { five: "six" } },
+            ],
+            job_options: { tags: %w[a b c d e f] },
+          )
+        end
+
+      assert_equal \
+        "Can't enqueue a job with more than 5 tags! (passed 6)",
+        error.message
+    end
+
+    it "should raise an error if any of the tags are too long" do
+      error =
+        assert_raises(Que::Error) do
+          Que::Job.bulk_enqueue(
+            [
+              { args: [1], kwargs: { two: "3" } },
+              { args: [4], kwargs: { five: "six" } },
+            ],
+            job_options: { tags: ["a" * 101] },
+          )
+        end
+
+      assert_equal \
+        "Can't enqueue a job with a tag longer than 100 characters! (\"#{"a" * 101}\")",
+        error.message
+    end
+  end
+
+  it "should respect a job class defined as a string" do
+    class MyJobClass < Que::Job; end
+
+    assert_enqueue(
+      expected_count: 2,
+      expected_args: [[1], [4]],
+      expected_kwargs: [{ two: "3" }, { five: "six" }],
+      expected_job_class: MyJobClass,
+      expected_result_class: Que::Job,
+    ) do
+      Que.bulk_enqueue(
+        [
+          { args: [1], kwargs: { two: "3" } },
+          { args: [4], kwargs: { five: "six" } },
+        ],
+        job_options: { job_class: 'MyJobClass' },
+      )
+    end
+  end
+
+  describe "when there's a hierarchy of job classes" do
+    class PriorityDefaultJob < Que::Job
+      self.priority = 3
+    end
+
+    class PrioritySubclassJob < PriorityDefaultJob
+    end
+
+    class RunAtDefaultJob < Que::Job
+      self.run_at = -> { Time.now + 30 }
+    end
+
+    class RunAtSubclassJob < RunAtDefaultJob
+    end
+
+    class QueueDefaultJob < Que::Job
+      self.queue = :queue_1
+    end
+
+    class QueueSubclassJob < QueueDefaultJob
+    end
+
+    describe "priority" do
+      it "should respect a default priority in a job class" do
+        assert_enqueue(
+          expected_count: 2,
+          expected_args: [[1], [4]],
+          expected_kwargs: [{ two: "3" }, { five: "six" }],
+          expected_priority: 3,
+          expected_job_class: PriorityDefaultJob,
+        ) do
+          PriorityDefaultJob.bulk_enqueue(
+            [
+              { args: [1], kwargs: { two: "3" } },
+              { args: [4], kwargs: { five: "six" } },
+            ],
+          )
+        end
+
+        assert_enqueue(
+          expected_count: 2,
+          expected_args: [[1], [4]],
+          expected_kwargs: [{ two: "3" }, { five: "six" }],
+          expected_priority: 4,
+          expected_job_class: PriorityDefaultJob,
+        ) do
+          PriorityDefaultJob.bulk_enqueue(
+            [
+              { args: [1], kwargs: { two: "3" } },
+              { args: [4], kwargs: { five: "six" } },
+            ],
+            job_options: { priority: 4 },
+          )
+        end
+      end
+
+      it "should respect an inherited priority in a job class" do
+        assert_enqueue(
+          expected_count: 2,
+          expected_args: [[1], [4]],
+          expected_kwargs: [{ two: "3" }, { five: "six" }],
+          expected_priority: 3,
+          expected_job_class: PrioritySubclassJob
+        ) do
+          PrioritySubclassJob.bulk_enqueue(
+            [
+              { args: [1], kwargs: { two: "3" } },
+              { args: [4], kwargs: { five: "six" } },
+            ],
+          )
+        end
+
+        assert_enqueue(
+          expected_count: 2,
+          expected_args: [[1], [4]],
+          expected_kwargs: [{ two: "3" }, { five: "six" }],
+          expected_priority: 4,
+          expected_job_class: PrioritySubclassJob
+        ) do
+          PrioritySubclassJob.bulk_enqueue(
+            [
+              { args: [1], kwargs: { two: "3" } },
+              { args: [4], kwargs: { five: "six" } },
+            ],
+            job_options: { priority: 4 },
+          )
+        end
+      end
+
+      it "should respect an overridden priority in a job class" do
+        begin
+          PrioritySubclassJob.priority = 60
+
+          assert_enqueue(
+            expected_count: 2,
+            expected_args: [[1], [4]],
+            expected_kwargs: [{ two: "3" }, { five: "six" }],
+            expected_priority: 60,
+            expected_job_class: PrioritySubclassJob
+          ) do
+            PrioritySubclassJob.bulk_enqueue(
+              [
+                { args: [1], kwargs: { two: "3" } },
+                { args: [4], kwargs: { five: "six" } },
+              ],
+            )
+          end
+
+          assert_enqueue(
+            expected_count: 2,
+            expected_args: [[1], [4]],
+            expected_kwargs: [{ two: "3" }, { five: "six" }],
+            expected_priority: 4,
+            expected_job_class: PrioritySubclassJob
+          ) do
+            PrioritySubclassJob.bulk_enqueue(
+              [
+                { args: [1], kwargs: { two: "3" } },
+                { args: [4], kwargs: { five: "six" } },
+              ],
+              job_options: { priority: 4 },
+            )
+          end
+        ensure
+          PrioritySubclassJob.remove_instance_variable(:@priority)
+        end
+      end
+    end
+
+    describe "run_at" do
+      it "should respect a default run_at in a job class" do
+        assert_enqueue(
+          expected_count: 2,
+          expected_args: [[1], [4]],
+          expected_kwargs: [{ two: "3" }, { five: "six" }],
+          expected_run_at: Time.now + 30,
+          expected_job_class: RunAtDefaultJob
+        ) do
+          RunAtDefaultJob.bulk_enqueue(
+            [
+              { args: [1], kwargs: { two: "3" } },
+              { args: [4], kwargs: { five: "six" } },
+            ],
+          )
+        end
+
+        assert_enqueue(
+          expected_count: 2,
+          expected_args: [[1], [4]],
+          expected_kwargs: [{ two: "3" }, { five: "six" }],
+          expected_run_at: Time.now + 60,
+          expected_job_class: RunAtDefaultJob
+        ) do
+          RunAtDefaultJob.bulk_enqueue(
+            [
+              { args: [1], kwargs: { two: "3" } },
+              { args: [4], kwargs: { five: "six" } },
+            ],
+            job_options: { run_at: Time.now + 60 },
+          )
+        end
+      end
+
+      it "should respect an inherited run_at in a job class" do
+        assert_enqueue(
+          expected_count: 2,
+          expected_args: [[1], [4]],
+          expected_kwargs: [{ two: "3" }, { five: "six" }],
+          expected_run_at: Time.now + 30,
+          expected_job_class: RunAtDefaultJob
+        ) do
+          RunAtDefaultJob.bulk_enqueue(
+            [
+              { args: [1], kwargs: { two: "3" } },
+              { args: [4], kwargs: { five: "six" } },
+            ],
+          )
+        end
+
+        assert_enqueue(
+          expected_count: 2,
+          expected_args: [[1], [4]],
+          expected_kwargs: [{ two: "3" }, { five: "six" }],
+          expected_run_at: Time.now + 60,
+          expected_job_class: RunAtDefaultJob
+        ) do
+          RunAtDefaultJob.bulk_enqueue(
+            [
+              { args: [1], kwargs: { two: "3" } },
+              { args: [4], kwargs: { five: "six" } },
+            ],
+            job_options: { run_at: Time.now + 60 },
+          )
+        end
+      end
+
+      it "should respect an overridden run_at in a job class" do
+        begin
+          RunAtSubclassJob.run_at = -> {Time.now + 90}
+
+          assert_enqueue(
+            expected_count: 2,
+            expected_args: [[1], [4]],
+            expected_kwargs: [{ two: "3" }, { five: "six" }],
+            expected_run_at: Time.now + 90,
+            expected_job_class: RunAtSubclassJob
+          ) do
+            RunAtSubclassJob.bulk_enqueue(
+              [
+                { args: [1], kwargs: { two: "3" } },
+                { args: [4], kwargs: { five: "six" } },
+              ],
+            )
+          end
+
+          assert_enqueue(
+            expected_count: 2,
+            expected_args: [[1], [4]],
+            expected_kwargs: [{ two: "3" }, { five: "six" }],
+            expected_run_at: Time.now + 60,
+            expected_job_class: RunAtSubclassJob
+          ) do
+            RunAtSubclassJob.bulk_enqueue(
+              [
+                { args: [1], kwargs: { two: "3" } },
+                { args: [4], kwargs: { five: "six" } },
+              ],
+              job_options: { run_at: Time.now + 60 },
+            )
+          end
+        ensure
+          RunAtSubclassJob.remove_instance_variable(:@run_at)
+        end
+      end
+    end
+
+    describe "queue" do
+      it "should respect a default queue in a job class" do
+        assert_enqueue(
+          expected_count: 2,
+          expected_args: [[1], [4]],
+          expected_kwargs: [{ two: "3" }, { five: "six" }],
+          expected_queue: 'queue_1',
+          expected_job_class: QueueDefaultJob
+        ) do
+          QueueDefaultJob.bulk_enqueue(
+            [
+              { args: [1], kwargs: { two: "3" } },
+              { args: [4], kwargs: { five: "six" } },
+            ],
+          )
+        end
+
+        assert_enqueue(
+          expected_count: 2,
+          expected_args: [[1], [4]],
+          expected_kwargs: [{ two: "3" }, { five: "six" }],
+          expected_queue: 'queue_3',
+          expected_job_class: QueueDefaultJob
+        ) do
+          QueueDefaultJob.bulk_enqueue(
+            [
+              { args: [1], kwargs: { two: "3" } },
+              { args: [4], kwargs: { five: "six" } },
+            ],
+            job_options: { queue: 'queue_3' },
+          )
+        end
+      end
+
+      it "should respect an inherited queue in a job class" do
+        assert_enqueue(
+          expected_count: 2,
+          expected_args: [[1], [4]],
+          expected_kwargs: [{ two: "3" }, { five: "six" }],
+          expected_queue: 'queue_1',
+          expected_job_class: QueueSubclassJob
+        ) do
+          QueueSubclassJob.bulk_enqueue(
+            [
+              { args: [1], kwargs: { two: "3" } },
+              { args: [4], kwargs: { five: "six" } },
+            ],
+          )
+        end
+
+        assert_enqueue(
+          expected_count: 2,
+          expected_args: [[1], [4]],
+          expected_kwargs: [{ two: "3" }, { five: "six" }],
+          expected_queue: 'queue_3',
+          expected_job_class: QueueSubclassJob
+        ) do
+          QueueSubclassJob.bulk_enqueue(
+            [
+              { args: [1], kwargs: { two: "3" } },
+              { args: [4], kwargs: { five: "six" } },
+            ],
+            job_options: { queue: 'queue_3' },
+          )
+        end
+      end
+
+      it "should respect an overridden queue in a job class" do
+        begin
+          QueueSubclassJob.queue = :queue_2
+
+          assert_enqueue(
+            expected_count: 2,
+            expected_args: [[1], [4]],
+            expected_kwargs: [{ two: "3" }, { five: "six" }],
+            expected_queue: 'queue_2',
+            expected_job_class: QueueSubclassJob
+          ) do
+            QueueSubclassJob.bulk_enqueue(
+              [
+                { args: [1], kwargs: { two: "3" } },
+                { args: [4], kwargs: { five: "six" } },
+              ],
+            )
+          end
+
+          assert_enqueue(
+            expected_count: 2,
+            expected_args: [[1], [4]],
+            expected_kwargs: [{ two: "3" }, { five: "six" }],
+            expected_queue: 'queue_3',
+            expected_job_class: QueueSubclassJob
+          ) do
+            QueueSubclassJob.bulk_enqueue(
+              [
+                { args: [1], kwargs: { two: "3" } },
+                { args: [4], kwargs: { five: "six" } },
+              ],
+              job_options: { queue: 'queue_3' },
+            )
+          end
+        ensure
+          QueueSubclassJob.remove_instance_variable(:@queue)
+        end
+      end
+    end
+  end
 end

--- a/spec/que/job.bulk_enqueue_spec.rb
+++ b/spec/que/job.bulk_enqueue_spec.rb
@@ -37,7 +37,7 @@ describe Que::Job, '.bulk_enqueue' do
       end
     end
 
-    jobs_dataset.each_with_index do |job, i|
+    jobs_dataset.order(:id).each_with_index do |job, i|
       assert_equal expected_queue, job[:queue]
       assert_equal expected_priority, job[:priority]
       assert_in_delta job[:run_at], expected_run_at, QueSpec::TIME_SKEW

--- a/spec/que/job.bulk_enqueue_spec.rb
+++ b/spec/que/job.bulk_enqueue_spec.rb
@@ -278,6 +278,14 @@ describe Que::Job, '.bulk_enqueue' do
     end
   end
 
+  it "should raise when job_options are passed to .enqueue rather than .bulk_enqueue" do
+    assert_raises_with_message(Que::Error, "When using .bulk_enqueue, job_options must be passed to that method rather than .enqueue") do
+      Que.bulk_enqueue do
+        Que.enqueue(1, two: "3", job_options: { priority: 15 })
+      end
+    end
+  end
+
   describe "when enqueuing jobs with tags" do
     it "should be able to specify tags on a case-by-case basis" do
       assert_enqueue(

--- a/spec/que/job.bulk_enqueue_spec.rb
+++ b/spec/que/job.bulk_enqueue_spec.rb
@@ -49,6 +49,16 @@ describe Que::Job, '.bulk_enqueue' do
     jobs_dataset.delete
   end
 
+  it "should be able to queue zero jobs without error" do
+    assert_enqueue(
+      expected_count: 0,
+      expected_args: [],
+      expected_kwargs: [],
+    ) do
+      Que.bulk_enqueue {}
+    end
+  end
+
   it "should be able to queue multiple jobs" do
     assert_enqueue(
       expected_count: 3,

--- a/spec/que/job.bulk_enqueue_spec.rb
+++ b/spec/que/job.bulk_enqueue_spec.rb
@@ -94,6 +94,93 @@ describe Que::Job, '.bulk_enqueue' do
     end
   end
 
+  describe "when bulk_enqueue args/kwargs are empty/omitted" do
+    it "can enqueue jobs with empty args" do
+      assert_enqueue(
+        expected_count: 2,
+        expected_args: [[], []],
+        expected_kwargs: [{ one: '2' }, {three: '4' }],
+      ) do
+        Que.bulk_enqueue(
+          [
+            { args: [], kwargs: { one: '2' } },
+            { args: [], kwargs: { three: '4' } },
+          ],
+        )
+      end
+    end
+
+    it "can enqueue jobs where args is omitted" do
+      assert_enqueue(
+        expected_count: 2,
+        expected_args: [[], []],
+        expected_kwargs: [{ one: '2' }, { three: '4' }],
+      ) do
+        Que.bulk_enqueue(
+          [
+            { kwargs: { one: '2' } },
+            { kwargs: { three: '4' } },
+          ],
+        )
+      end
+    end
+
+    it "can enqueue jobs where kwargs is omitted" do
+      assert_enqueue(
+        expected_count: 2,
+        expected_args: [[1], [2]],
+        expected_kwargs: [{}, {}],
+      ) do
+        Que.bulk_enqueue(
+          [
+            { args: [1] },
+            { args: [2] },
+          ],
+        )
+      end
+    end
+
+    it "can enqueue jobs where args and kwargs is omitted" do
+      assert_enqueue(
+        expected_count: 2,
+        expected_args: [[], []],
+        expected_kwargs: [{}, {}],
+      ) do
+        Que.bulk_enqueue([{}, {}])
+      end
+    end
+
+    it "can enqueue jobs with empty args" do
+      assert_enqueue(
+        expected_count: 2,
+        expected_args: [[], []],
+        expected_kwargs: [{ one: '2' }, { three: '4' }],
+      ) do
+        Que.bulk_enqueue(
+          [
+            { args: [], kwargs: { one: '2' } },
+            { args: [], kwargs: { three: '4' } },
+          ],
+        )
+      end
+    end
+
+    it "can enqueue jobs with empty kwargs" do
+      assert_enqueue(
+        expected_count: 2,
+        expected_args: [[1], [2]],
+        expected_kwargs: [{}, {}]
+      ) do
+        Que.bulk_enqueue(
+          [
+            { args: [1], kwargs: {} },
+            { args: [2], kwargs: {} },
+          ],
+        )
+      end
+    end
+  end
+
   it "should be able to handle a namespaced job class" do
     assert_enqueue(
       expected_count: 2,

--- a/spec/que/migrations.state_trigger_spec.rb
+++ b/spec/que/migrations.state_trigger_spec.rb
@@ -232,4 +232,18 @@ describe Que::Migrations, "que_state trigger" do
       end
     end
   end
+
+  it "should not notify when using bulk_enqueue" do
+    Que.bulk_enqueue do
+      Que.enqueue(job_class: "MyJobClass")
+    end
+    assert_nil get_message(timeout: 0.1, expect_nothing: true)
+  end
+
+  it "should notify when using bulk_enqueue with 'notify: true'" do
+    Que.bulk_enqueue(notify: true) do
+      Que.enqueue(job_class: "MyJobClass")
+    end
+    assert get_message
+  end
 end

--- a/spec/que/migrations.work_job_trigger_spec.rb
+++ b/spec/que/migrations.work_job_trigger_spec.rb
@@ -135,12 +135,10 @@ describe Que::Migrations, "job_available trigger" do
     listen_connection do |conn|
       DB[:que_lockers].insert(locker_attrs)
       conn.async_exec "LISTEN que_listener_1"
-      Que::Job.bulk_enqueue(
-        [
-          { args: ['job1_arg1'], kwargs: { job1_kwarg1: 'x' } },
-          { args: ['job2_arg1'], kwargs: { job2_kwarg1: 'x' } },
-        ],
-      )
+      Que.bulk_enqueue do
+        Que::Job.enqueue('job1_arg1', job1_kwarg1: 'x')
+        Que::Job.enqueue('job2_arg1', job2_kwarg1: 'x')
+      end
       assert_nil conn.wait_for_notify(0.01)
     end
   end

--- a/spec/que/migrations.work_job_trigger_spec.rb
+++ b/spec/que/migrations.work_job_trigger_spec.rb
@@ -130,4 +130,18 @@ describe Que::Migrations, "job_available trigger" do
       assert_nil conn.wait_for_notify(0.01)
     end
   end
+
+  it "should not notify a locker when using bulk_enqueue" do
+    listen_connection do |conn|
+      DB[:que_lockers].insert(locker_attrs)
+      conn.async_exec "LISTEN que_listener_1"
+      Que::Job.bulk_enqueue(
+        [
+          { args: ['job1_arg1'], kwargs: { job1_kwarg1: 'x' } },
+          { args: ['job2_arg1'], kwargs: { job2_kwarg1: 'x' } },
+        ],
+      )
+      assert_nil conn.wait_for_notify(0.01)
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -211,6 +211,11 @@ class QueSpec < Minitest::Spec
     end
   end
 
+  def assert_raises_with_message(expected_error_class, expected_message, &block)
+    e = assert_raises(expected_error_class, &block)
+    assert_match(expected_message, e.message, "#{mu_pp(expected_error_class)} error was raised but without the expected message")
+  end
+
   class << self
     # More easily hammer a certain spec.
     def hit(*args, &block)


### PR DESCRIPTION
Resolves: https://github.com/que-rb/que/issues/333

**Todo**:

- [x] This was built on top of the ruby3 branch (#319) - clean it up after that is merged
- [x] Complete specs for `.bulk_enqueue`
- [x] Rework interface to use block form instead with normal calls to `.enqueue`
- [x] Disable `que_job_notify` trigger in `.bulk_enqueue` for performance
- [x] Disable `que_state_notify` trigger in `.bulk_enqueue` for performance / ~~completely remove it~~ ([removal deferred](https://github.com/que-rb/que/issues/372))
- [x] Deprecate `que_state_notify` trigger in the changelog
- [x] Add option to enable notify in `.bulk_enqueue`
- [x] Test `.bulk_enqueue` in synchronous mode
- [x] Write documentation
- [x] Update mass-job-deletion docs to use `que.skip_notify`
- [x] Determine performance improvement
- [x] ~~Add a test for enqueueing a job with ActiveJob within a `.bulk_enqueue` block~~
  - ActiveJob does not have a bulk enqueue interface and ActiveJob always adds job options to the Que.enqueue call which we do not support.
- [x] Add migration instructions to changelog
- [x] ~~Confirm that the alternate instructions in the ActiveJob error message actually work for ActiveJob jobs~~ - it didn't: removed
- [x] Note ActiveJob incompatibility in the docs with alternate instructions

**To PR and release subsequently**:

- Support enqueueing different job classes within a `.bulk_enqueue` block
- Support enqueueing different job_options within a `.bulk_enqueue` block
- Deduplicate common code in enqueue and bulk enqueue paths