### PR TITLE
Fix startup error: `undefined method 'job_schema_version' for Que:Module`

### DIFF
--- a/lib/que.rb
+++ b/lib/que.rb
@@ -31,6 +31,8 @@ module Que
   require_relative 'que/utils/queue_management'
   require_relative 'que/utils/transactions'
 
+  require_relative 'que/version'
+
   require_relative 'que/connection'
   require_relative 'que/connection_pool'
   require_relative 'que/job_methods'
@@ -41,7 +43,6 @@ module Que
   require_relative 'que/migrations'
   require_relative 'que/poller'
   require_relative 'que/result_queue'
-  require_relative 'que/version'
   require_relative 'que/worker'
 
   class << self


### PR DESCRIPTION
Que was throwing an error on startup, and even for a simple command like `que --version`:

```
➜ que --version
Traceback (most recent call last):
	18: from /home/brendan/.rbenv/versions/2.7.3/bin/que:25:in `<main>'
	17: from /home/brendan/.rbenv/versions/2.7.3/bin/que:25:in `load'
	16: from /home/brendan/.rbenv/versions/2.7.3/lib/ruby/gems/2.7.0/gems/que-1.3.0/bin/que:9:in `<top (required)>'
	15: from /home/brendan/.rbenv/versions/2.7.3/lib/ruby/gems/2.7.0/gems/que-1.3.0/bin/command_line_interface.rb:157:in `parse'
	14: from /home/brendan/.rbenv/versions/2.7.3/lib/ruby/2.7.0/optparse.rb:1691:in `parse!'
	13: from /home/brendan/.rbenv/versions/2.7.3/lib/ruby/2.7.0/optparse.rb:1666:in `permute!'
	12: from /home/brendan/.rbenv/versions/2.7.3/lib/ruby/2.7.0/optparse.rb:1569:in `order!'
	11: from /home/brendan/.rbenv/versions/2.7.3/lib/ruby/2.7.0/optparse.rb:1575:in `parse_in_order'
	10: from /home/brendan/.rbenv/versions/2.7.3/lib/ruby/2.7.0/optparse.rb:1575:in `catch'
	9: from /home/brendan/.rbenv/versions/2.7.3/lib/ruby/2.7.0/optparse.rb:1589:in `block in parse_in_order'
	8: from /home/brendan/.rbenv/versions/2.7.3/lib/ruby/gems/2.7.0/gems/que-1.3.0/bin/command_line_interface.rb:108:in `block (2 levels) in parse'
	7: from /home/brendan/.rbenv/versions/2.7.3/lib/ruby/site_ruby/2.7.0/rubygems/core_ext/kernel_require.rb:85:in `require'
	6: from /home/brendan/.rbenv/versions/2.7.3/lib/ruby/site_ruby/2.7.0/rubygems/core_ext/kernel_require.rb:85:in `require'
	5: from /home/brendan/.rbenv/versions/2.7.3/lib/ruby/gems/2.7.0/gems/que-1.3.0/lib/que.rb:6:in `<top (required)>'
	4: from /home/brendan/.rbenv/versions/2.7.3/lib/ruby/gems/2.7.0/gems/que-1.3.0/lib/que.rb:37:in `<module:Que>'
	3: from /home/brendan/.rbenv/versions/2.7.3/lib/ruby/gems/2.7.0/gems/que-1.3.0/lib/que.rb:37:in `require_relative'
	2: from /home/brendan/.rbenv/versions/2.7.3/lib/ruby/gems/2.7.0/gems/que-1.3.0/lib/que/job.rb:5:in `<top (required)>'
	1: from /home/brendan/.rbenv/versions/2.7.3/lib/ruby/gems/2.7.0/gems/que-1.3.0/lib/que/job.rb:6:in `<module:Que>'
/home/brendan/.rbenv/versions/2.7.3/lib/ruby/gems/2.7.0/gems/que-1.3.0/lib/que/job.rb:24:in `<class:Job>': undefined method `job_schema_version' for Que:Module (NoMethodError)
```

The version file now needs to be required earlier, since `Que.job_schema_version` is used at require time by other files.

Somehow, this error doesn't occur when running Que from its own repo, or using it by `path:` in a Gemfile... So it sadly went undetected!