### PR TITLE
Remove unused `--minimum-buffer-size` option

### DIFF
--- a/bin/command_line_interface.rb
+++ b/bin/command_line_interface.rb
@@ -136,6 +136,14 @@ module Que
             end
 
             opts.on(
+              '--minimum-buffer-size [SIZE]',
+              Integer,
+              "Unused (deprecated)",
+            ) do |s|
+              warn "The --minimum-buffer-size SIZE option has been deprecated and will be removed in v2.0 (it's actually been unused since v1.0.0.beta4)"
+            end
+
+            opts.on(
               '--wait-period [PERIOD]',
               Float,
               "Set maximum interval between checks of the in-memory job queue, " \

--- a/bin/command_line_interface.rb
+++ b/bin/command_line_interface.rb
@@ -136,15 +136,6 @@ module Que
             end
 
             opts.on(
-              '--minimum-buffer-size [SIZE]',
-              Integer,
-              "Set minimum number of jobs to be locked and held in this " \
-                "process awaiting a worker (default: 2)",
-            ) do |s|
-              options[:minimum_buffer_size] = s
-            end
-
-            opts.on(
               '--wait-period [PERIOD]',
               Float,
               "Set maximum interval between checks of the in-memory job queue, " \
@@ -236,7 +227,7 @@ OUTPUT
           <<~STARTUP
             Que #{Que::VERSION} started worker process with:
               Worker threads: #{locker.workers.length} (priorities: #{locker.workers.map { |w| w.priority || 'any' }.join(', ')})
-              Buffer size: #{locker.job_buffer.minimum_size}-#{locker.job_buffer.maximum_size}
+              Buffer size: #{locker.job_buffer.maximum_size}
               Queues:
             #{locker.queues.map { |queue, interval| "    - #{queue} (poll interval: #{interval}s)" }.join("\n")}
             Que waiting for jobs...

--- a/bin/command_line_interface.spec.rb
+++ b/bin/command_line_interface.spec.rb
@@ -190,7 +190,6 @@ MSG
       poll_interval: 5,
       wait_period: 50,
       queues: ['default'],
-      minimum_buffer_size: 2,
       maximum_buffer_size: 8
     )
 
@@ -204,7 +203,6 @@ MSG
       assert_equal queues,              locker_instantiate[:queues]
       assert_equal poll_interval,       locker_instantiate[:poll_interval]
       assert_equal wait_period,         locker_instantiate[:wait_period]
-      assert_equal minimum_buffer_size, locker_instantiate[:minimum_buffer_size]
       assert_equal maximum_buffer_size, locker_instantiate[:maximum_buffer_size]
       assert_equal worker_priorities,   locker_instantiate[:worker_priorities]
     end
@@ -307,21 +305,11 @@ MSG
 
     it "with a configurable local queue size" do
       assert_successful_invocation \
-        "./#{filename} --minimum-buffer-size 8 --maximum-buffer-size 20"
+        "./#{filename} --maximum-buffer-size 20"
 
       assert_locker_instantiated(
-        minimum_buffer_size: 8,
         maximum_buffer_size: 20,
       )
-    end
-
-    it "should raise an error if the minimum_buffer_size is above the maximum_buffer_size" do
-      code = execute("./#{filename} --minimum-buffer-size 10")
-      assert_equal 1, code
-      assert_equal 1, output.messages.length
-      assert_equal \
-        "minimum buffer size (10) is greater than the maximum buffer size (8)!",
-        output.messages.first.to_s
     end
 
     it "with a configurable log level" do
@@ -437,7 +425,7 @@ MSG
     file_name = write_file
 
     assert_successful_invocation(
-      "./#{file_name} -w 6 -p 1,2,3,4 -i 1.2 -q a=10 -q b=20.05 -q c --minimum-buffer-size 0 --maximum-buffer-size 1",
+      "./#{file_name} -w 6 -p 1,2,3,4 -i 1.2 -q a=10 -q b=20.05 -q c --maximum-buffer-size 1",
       queue_name: 'a',
     )
 
@@ -447,7 +435,7 @@ MSG
           <<~STARTUP
             Que #{Que::VERSION} started worker process with:
               Worker threads: 6 (priorities: 1, 2, 3, 4, any, any)
-              Buffer size: 0-1
+              Buffer size: 1
               Queues:
                 - a (poll interval: 10.0s)
                 - b (poll interval: 20.05s)

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ Docs Index
 - [Command Line Interface](#command-line-interface)
   * [worker-priorities and worker-count](#worker-priorities-and-worker-count)
   * [poll-interval](#poll-interval)
-  * [minimum-buffer-size and maximum-buffer-size](#minimum-buffer-size-and-maximum-buffer-size)
+  * [maximum-buffer-size](#maximum-buffer-size)
   * [connection-url](#connection-url)
   * [wait-period](#wait-period)
   * [log-internals](#log-internals)
@@ -62,7 +62,6 @@ usage: que [options] [file/to/require] ...
         --connection-url [URL]       Set a custom database url to connect to for locking purposes.
         --log-internals              Log verbosely about Que's internal state. Only recommended for debugging issues
         --maximum-buffer-size [SIZE] Set maximum number of jobs to be locked and held in this process awaiting a worker (default: 8)
-        --minimum-buffer-size [SIZE] Set minimum number of jobs to be locked and held in this process awaiting a worker (default: 2)
         --wait-period [PERIOD]       Set maximum interval between checks of the in-memory job queue, in milliseconds (default: 50)
 ```
 
@@ -82,9 +81,9 @@ If you pass both worker-count and worker-priorities, the count will trim or pad 
 
 This option sets the number of seconds the process will wait between polls of the job queue. Jobs that are ready to be worked immediately will be broadcast via the LISTEN/NOTIFY system, so polling is unnecessary for them - polling is only necessary for jobs that are scheduled in the future or which are being delayed due to errors. The default is 5 seconds.
 
-### minimum-buffer-size and maximum-buffer-size
+### maximum-buffer-size
 
-These options set the size of the internal buffer that Que uses to hold jobs until they're ready for workers. The default minimum is 2 and the maximum is 8, meaning that the process won't buffer more than 8 jobs that aren't yet ready to be worked, and will only resort to polling if the buffer dips below 2. If you don't want jobs to be buffered at all, you can set both of these values to zero.
+This option sets the size of the internal buffer that Que uses to hold jobs until they're ready for workers. The default maximum is 8, meaning that the process won't buffer more than 8 jobs that aren't yet ready to be worked. If you don't want jobs to be buffered at all, you can set this value to zero.
 
 ### connection-url
 

--- a/lib/que/job_buffer.available_priorities_spec.rb
+++ b/lib/que/job_buffer.available_priorities_spec.rb
@@ -22,12 +22,10 @@ describe Que::JobBuffer, "available_priorities" do
   end
 
   let(:maximum_size) { 8 }
-  let(:minimum_size) { 2 }
 
   let :job_buffer do
     Que::JobBuffer.new(
       maximum_size: maximum_size,
-      minimum_size: minimum_size,
       priorities: worker_priorities.uniq,
     )
   end
@@ -116,7 +114,6 @@ describe Que::JobBuffer, "available_priorities" do
 
   describe "when the maximum buffer size is zero" do
     let(:maximum_size) { 0 }
-    let(:minimum_size) { 0 }
 
     describe "and all the workers are free" do
       it "should not include any buffer space in the available counts" do

--- a/lib/que/job_buffer.rb
+++ b/lib/que/job_buffer.rb
@@ -6,7 +6,7 @@
 
 module Que
   class JobBuffer
-    attr_reader :maximum_size, :minimum_size, :priority_queues
+    attr_reader :maximum_size, :priority_queues
 
     # Since we use a mutex, which is not reentrant, we have to be a little
     # careful to not call a method that locks the mutex when we've already
@@ -17,19 +17,10 @@ module Que
 
     def initialize(
       maximum_size:,
-      minimum_size:,
       priorities:
     )
       @maximum_size = Que.assert(Integer, maximum_size)
       Que.assert(maximum_size >= 0) { "maximum_size for a JobBuffer must be at least zero!" }
-
-      @minimum_size = Que.assert(Integer, minimum_size)
-      Que.assert(minimum_size >= 0) { "minimum_size for a JobBuffer must be at least zero!" }
-
-      Que.assert(minimum_size <= maximum_size) do
-        "minimum buffer size (#{minimum_size}) is " \
-          "greater than the maximum buffer size (#{maximum_size})!"
-      end
 
       @stop  = false
       @array = []

--- a/lib/que/job_buffer.spec.rb
+++ b/lib/que/job_buffer.spec.rb
@@ -9,7 +9,6 @@ describe Que::JobBuffer do
   let :job_buffer do
     Que::JobBuffer.new(
       maximum_size: maximum_size,
-      minimum_size: 0,
       priorities: [10, 30, 50, nil].shuffle,
     )
   end
@@ -36,26 +35,10 @@ describe Que::JobBuffer do
   describe "during instantiation" do
     it "should raise an error if passed a maximum buffer size less than zero" do
       error = assert_raises(Que::Error) do
-        Que::JobBuffer.new(minimum_size: 0, maximum_size: -1, priorities: [10])
+        Que::JobBuffer.new(maximum_size: -1, priorities: [10])
       end
 
       assert_equal "maximum_size for a JobBuffer must be at least zero!", error.message
-    end
-
-    it "should raise an error if passed a minimum buffer size less than zero" do
-      error = assert_raises(Que::Error) do
-        Que::JobBuffer.new(minimum_size: -1, maximum_size: 8, priorities: [10])
-      end
-
-      assert_equal "minimum_size for a JobBuffer must be at least zero!", error.message
-    end
-
-    it "should raise an error if passed a minimum buffer size larger than its maximum" do
-      error = assert_raises(Que::Error) do
-        Que::JobBuffer.new(minimum_size: 10, maximum_size: 8, priorities: [10])
-      end
-
-      assert_equal "minimum buffer size (10) is greater than the maximum buffer size (8)!", error.message
     end
   end
 
@@ -260,7 +243,6 @@ describe Que::JobBuffer do
         job_buffer =
           Que::JobBuffer.new(
             maximum_size: maximum_size,
-            minimum_size: 0,
             priorities: [10],
           )
 

--- a/lib/que/locker.rb
+++ b/lib/que/locker.rb
@@ -45,7 +45,6 @@ module Que
 
     DEFAULT_POLL_INTERVAL       = 5.0
     DEFAULT_WAIT_PERIOD         = 50
-    DEFAULT_MINIMUM_BUFFER_SIZE = 2
     DEFAULT_MAXIMUM_BUFFER_SIZE = 8
     DEFAULT_WORKER_PRIORITIES   = [10, 30, 50, nil, nil, nil].freeze
 
@@ -57,7 +56,6 @@ module Que
       poll_interval:       DEFAULT_POLL_INTERVAL,
       wait_period:         DEFAULT_WAIT_PERIOD,
       maximum_buffer_size: DEFAULT_MAXIMUM_BUFFER_SIZE,
-      minimum_buffer_size: DEFAULT_MINIMUM_BUFFER_SIZE,
       worker_priorities:   DEFAULT_WORKER_PRIORITIES,
       on_worker_start:     nil
     )
@@ -77,7 +75,6 @@ module Que
       # ResultQueue to receive messages from workers.
       @job_buffer = JobBuffer.new(
         maximum_size: maximum_buffer_size,
-        minimum_size: minimum_buffer_size,
         priorities:   worker_priorities.uniq,
       )
 
@@ -93,7 +90,6 @@ module Que
           poll_interval:       poll_interval,
           wait_period:         wait_period,
           maximum_buffer_size: maximum_buffer_size,
-          minimum_buffer_size: minimum_buffer_size,
           worker_priorities:   worker_priorities,
         }
       end

--- a/lib/que/locker.spec.rb
+++ b/lib/que/locker.spec.rb
@@ -36,7 +36,6 @@ describe Que::Locker do
       locker_settings.merge!(
         queues:              ['my_queue'],
         listen:              false,
-        minimum_buffer_size: 5,
         maximum_buffer_size: 45,
         wait_period:         200,
         poll_interval:       0.4,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -162,7 +162,7 @@ class QueSpec < Minitest::Spec
   end
 
   let :job_buffer do
-    Que::JobBuffer.new(maximum_size: 20, minimum_size: 0, priorities: [10, 30, 50, nil])
+    Que::JobBuffer.new(maximum_size: 20, priorities: [10, 30, 50, nil])
   end
 
   let :result_queue do


### PR DESCRIPTION
It became unused in https://github.com/que-rb/que/commit/1736d3a30612f90a6839c5f98f622c9585e51784, so since v1.0.0.beta4.

It's just confusing things now, e.g. in:

- https://github.com/que-rb/que/issues/345
- https://github.com/que-rb/que/issues/331