### PR TITLE
Continue polling for jobs when only some of the waiting worker priorities will be fully utilised

### DIFF
--- a/lib/que/poller.rb
+++ b/lib/que/poller.rb
@@ -269,6 +269,13 @@ module Que
     private
 
     def any_priority_satisfied?(priorities, jobs)
+      worker_jobs = allocate_jobs_to_workers(priorities, jobs)
+      priorities.any? do |worker_priority, waiting_workers_count|
+        worker_jobs[worker_priority].length == waiting_workers_count
+      end
+    end
+
+    def allocate_jobs_to_workers(priorities, jobs)
       jobs = jobs.sort_by { |job| job.fetch(:priority) }
       worker_jobs = {}
       priorities.each do |worker_priority, waiting_workers_count|
@@ -282,9 +289,7 @@ module Que
           end
         end
       end
-      priorities.any? do |worker_priority, waiting_workers_count|
-        worker_jobs[worker_priority].length == waiting_workers_count
-      end
+      worker_jobs
     end
   end
 end

--- a/lib/que/poller.rb
+++ b/lib/que/poller.rb
@@ -146,8 +146,6 @@ module Que
 
       return unless should_poll?
 
-      expected_count = priorities.inject(0){|s,(_,c)| s + c}
-
       jobs =
         connection.execute_prepared(
           :poll_jobs,

--- a/lib/que/poller.rb
+++ b/lib/que/poller.rb
@@ -274,10 +274,9 @@ module Que
       priorities.any? do |worker_priority, waiting_workers_count|
         waiting_workers_count.times do
           return false if job_priorities.empty?
-          if job_priorities.first <= worker_priority
-            job_priorities.shift
-            worker_job_counts[worker_priority] += 1
-          end
+          break if job_priorities.first > worker_priority
+          job_priorities.shift
+          worker_job_counts[worker_priority] += 1
         end
         worker_job_counts[worker_priority] == waiting_workers_count
       end

--- a/lib/que/poller.rb
+++ b/lib/que/poller.rb
@@ -269,25 +269,18 @@ module Que
     private
 
     def any_priority_satisfied?(priorities, jobs)
-      worker_job_counts = workers_jobs_allocation_counts(priorities, jobs)
-      priorities.any? do |worker_priority, waiting_workers_count|
-        worker_job_counts[worker_priority] == waiting_workers_count
-      end
-    end
-
-    def workers_jobs_allocation_counts(priorities, jobs)
       job_priorities = jobs.map { |job| job.fetch(:priority) }.sort
       worker_job_counts = Hash.new(0)
-      priorities.each do |worker_priority, waiting_workers_count|
+      priorities.any? do |worker_priority, waiting_workers_count|
         waiting_workers_count.times do
-          next if job_priorities.empty?
+          return false if job_priorities.empty?
           if job_priorities.first <= worker_priority
             job_priorities.shift
             worker_job_counts[worker_priority] += 1
           end
         end
+        worker_job_counts[worker_priority] == waiting_workers_count
       end
-      worker_job_counts
     end
   end
 end

--- a/lib/que/poller.spec.rb
+++ b/lib/que/poller.spec.rb
@@ -255,29 +255,61 @@ describe Que::Poller do
       assert poller.should_poll?
     end
 
-    it "should be true if the last poll returned a full complement of jobs" do
-      jobs = 5.times.map { Que::Job.enqueue }
+    it "should be true if the jobs returned from the last poll satisfied all given priorities" do
+      job_ids_p10 = 3.times.map { Que::Job.enqueue(job_options: { priority: 10 }).que_attrs[:id] }
+      job_ids_p20 = 2.times.map { Que::Job.enqueue(job_options: { priority: 20 }).que_attrs[:id] }
 
-      result = poller.poll(priorities: {500 => 3}, held_locks: Set.new)
-      assert_equal 3, result.length
+      result = poller.poll(priorities: { 10 => 3, 20 => 2 }, held_locks: Set.new)
+      assert_equal (job_ids_p10 + job_ids_p20), result.map(&:id)
 
       assert_equal true, poller.should_poll?
     end
 
-    it "should be false if the last poll didn't return a full complement of jobs" do
-      jobs = 5.times.map { Que::Job.enqueue }
+    it "should be true if the jobs returned from the last poll satisfied any given priority" do
+      job_ids_p10 = 2.times.map { Que::Job.enqueue(job_options: { priority: 10 }).que_attrs[:id] }
+      job_ids_p20 = 2.times.map { Que::Job.enqueue(job_options: { priority: 20 }).que_attrs[:id] }
 
-      result = poller.poll(priorities: {500 => 7}, held_locks: Set.new)
-      assert_equal 5, result.length
+      result = poller.poll(priorities: { 10 => 2, 20 => 1 }, held_locks: Set.new)
+      assert_equal (job_ids_p10 + [job_ids_p20.first]), result.map(&:id)
+
+      assert_equal true, poller.should_poll?
+    end
+
+    it "should be true if the jobs returned from the last poll satisfied any given priority and were slightly higher priority than each priority requested" do
+      job_ids_p10 = 2.times.map { Que::Job.enqueue(job_options: { priority: 10 }).que_attrs[:id] }
+      job_ids_p20 = 2.times.map { Que::Job.enqueue(job_options: { priority: 20 }).que_attrs[:id] }
+
+      result = poller.poll(priorities: { 11 => 2, 21 => 1 }, held_locks: Set.new)
+      assert_equal (job_ids_p10 + [job_ids_p20.first]), result.map(&:id)
+
+      assert_equal true, poller.should_poll?
+    end
+
+    it "should be true if the jobs returned from the last poll satisfied any given priority and a lower priority request was upgraded to high priority" do
+      job_ids_p10 = 5.times.map { Que::Job.enqueue(job_options: { priority: 10 }).que_attrs[:id] }
+      job_ids_p20 = 2.times.map { Que::Job.enqueue(job_options: { priority: 20 }).que_attrs[:id] }
+
+      result = poller.poll(priorities: { 10 => 3, 20 => 2 }, held_locks: Set.new)
+      assert_equal job_ids_p10, result.map(&:id)
+
+      assert_equal true, poller.should_poll?
+    end
+
+    it "should be false if the jobs returned from the last poll didn't return a full complement of jobs matching any given priority" do
+      job_ids_p10 = 5.times.map { Que::Job.enqueue(job_options: { priority: 10 }).que_attrs[:id] }
+      job_ids_p20 = 2.times.map { Que::Job.enqueue(job_options: { priority: 20 }).que_attrs[:id] }
+
+      result = poller.poll(priorities: { 10 => 6, 20 => 3 }, held_locks: Set.new)
+      assert_equal (job_ids_p10 + job_ids_p20), result.map(&:id)
 
       assert_equal false, poller.should_poll?
     end
 
-    it "should be true if the last poll didn't return a full complement of jobs, but the poll_interval has elapsed" do
-      jobs = 5.times.map { Que::Job.enqueue }
+    it "should be true if the jobs returned from the last poll didn't return a full complement of jobs, but the poll_interval has elapsed" do
+      job_ids = 5.times.map { Que::Job.enqueue.que_attrs[:id] }
 
-      result = poller.poll(priorities: {500 => 7}, held_locks: Set.new)
-      assert_equal 5, result.length
+      result = poller.poll(priorities: { 500 => 7 }, held_locks: Set.new)
+      assert_equal job_ids, result.map(&:id)
 
       poller.instance_variable_set(:@last_polled_at, Time.now - 30)
       assert_equal true, poller.should_poll?

--- a/lib/que/poller.spec.rb
+++ b/lib/que/poller.spec.rb
@@ -255,7 +255,7 @@ describe Que::Poller do
       assert poller.should_poll?
     end
 
-    it "should be true if the jobs returned from the last poll satisfied all given priorities" do
+    it "should be true if the jobs returned from the last poll satisfied all priority requests" do
       job_ids_p10 = 3.times.map { Que::Job.enqueue(job_options: { priority: 10 }).que_attrs[:id] }
       job_ids_p20 = 2.times.map { Que::Job.enqueue(job_options: { priority: 20 }).que_attrs[:id] }
 
@@ -265,7 +265,7 @@ describe Que::Poller do
       assert_equal true, poller.should_poll?
     end
 
-    it "should be true if the jobs returned from the last poll satisfied any given priority" do
+    it "should be true if the jobs returned from the last poll satisfied any priority request" do
       job_ids_p10 = 2.times.map { Que::Job.enqueue(job_options: { priority: 10 }).que_attrs[:id] }
       job_ids_p20 = 2.times.map { Que::Job.enqueue(job_options: { priority: 20 }).que_attrs[:id] }
 
@@ -275,7 +275,7 @@ describe Que::Poller do
       assert_equal true, poller.should_poll?
     end
 
-    it "should be true if the jobs returned from the last poll satisfied any given priority and were slightly higher priority than each priority requested" do
+    it "should be true if the jobs returned from the last poll satisfied any priority request and were slightly higher priority than each priority requested" do
       job_ids_p10 = 2.times.map { Que::Job.enqueue(job_options: { priority: 10 }).que_attrs[:id] }
       job_ids_p20 = 2.times.map { Que::Job.enqueue(job_options: { priority: 20 }).que_attrs[:id] }
 
@@ -285,7 +285,7 @@ describe Que::Poller do
       assert_equal true, poller.should_poll?
     end
 
-    it "should be true if the jobs returned from the last poll satisfied any given priority and a lower priority request was upgraded to high priority" do
+    it "should be true if the jobs returned from the last poll satisfied any priority request and a lower priority request was upgraded to high priority" do
       job_ids_p10 = 5.times.map { Que::Job.enqueue(job_options: { priority: 10 }).que_attrs[:id] }
       job_ids_p20 = 2.times.map { Que::Job.enqueue(job_options: { priority: 20 }).que_attrs[:id] }
 
@@ -295,7 +295,7 @@ describe Que::Poller do
       assert_equal true, poller.should_poll?
     end
 
-    it "should be false if the jobs returned from the last poll didn't return a full complement of jobs matching any given priority" do
+    it "should be false if the jobs returned from the last poll didn't satisfy any priority request" do
       job_ids_p10 = 5.times.map { Que::Job.enqueue(job_options: { priority: 10 }).que_attrs[:id] }
       job_ids_p20 = 2.times.map { Que::Job.enqueue(job_options: { priority: 20 }).que_attrs[:id] }
 
@@ -305,7 +305,7 @@ describe Que::Poller do
       assert_equal false, poller.should_poll?
     end
 
-    it "should be true if the jobs returned from the last poll didn't return a full complement of jobs, but the poll_interval has elapsed" do
+    it "should be true if the jobs returned from the last poll didn't satisfy any priority request, but the poll_interval has elapsed" do
       job_ids = 5.times.map { Que::Job.enqueue.que_attrs[:id] }
 
       result = poller.poll(priorities: { 500 => 7 }, held_locks: Set.new)


### PR DESCRIPTION
Resolves https://github.com/que-rb/que/issues/345.

Basically, this is all about polling again immediately if there are a decent number of jobs we need to get through. But 'decent number of jobs' needs a good definition.

Previously, all idle worker priorities needed to be fully utilised by the jobs from a poll in order to not sleep before the next poll. This change makes it so that sleeping is skipped if *any* waiting worker priority is fully satisfied by the jobs from the poll.

Determining whether a worker priority would be fully utilised turned out to be far less trivial than I first thought it'd be. You have to take into account that jobs with a higher priority (a smaller number) than a worker's priority also match it.

I'm sure there's a more functional programming way to do this, but I couldn't think of it!

This was kinda hard to explain, so wording suggestions more than welcome.

A simpler alternative would be to just sleep if there are no jobs returned from the poll. That'd incur an extra poll when only a small number of jobs come in, but might be worth the ability to avoid this PR's increase in code complexity? I've kinda had to reimplement allocating jobs to workers!

Manually tested:

```
➜ ruby -r bundler/setup -r ./app.rb -e 'DB[:que_jobs].truncate; [1, 2].each { |priority| 10.times { MyJob.enqueue(job_options: { priority: priority }) } }' && bundle exec que --worker-priorities 1,2 --poll-interval 2 --minimum-buffer-size 0 --maximum-buffer-size 0 --log-level debug --log-internals ./app.rb | grep -E '(newly_locked|Running MyJob)'
I, [2022-03-04T00:09:57.981221 #2692386]  INFO -- : {"lib":"que","hostname":"ZimbiX-GreenSync","pid":2692386,"thread":2360,"internal_event":"poller_polled","object_id":2420,"t":"2022-03-03T13:09:57.981175Z","queue":"default","locked":2,"priorities":{"2":1,"1":1},"held_locks":[],"newly_locked":[805503879,805503880]}
I, [2022-03-04T00:09:57.983762 #2692386]  INFO -- : Running MyJob - priority: 1
I, [2022-03-04T00:09:57.988989 #2692386]  INFO -- : Running MyJob - priority: 1
I, [2022-03-04T00:09:58.036137 #2692386]  INFO -- : {"lib":"que","hostname":"ZimbiX-GreenSync","pid":2692386,"thread":2360,"internal_event":"poller_polled","object_id":2420,"t":"2022-03-03T13:09:58.036092Z","queue":"default","locked":2,"priorities":{"2":1,"1":1},"held_locks":[],"newly_locked":[805503881,805503882]}
I, [2022-03-04T00:09:58.038124 #2692386]  INFO -- : Running MyJob - priority: 1
I, [2022-03-04T00:09:58.038463 #2692386]  INFO -- : Running MyJob - priority: 1
I, [2022-03-04T00:09:58.091545 #2692386]  INFO -- : {"lib":"que","hostname":"ZimbiX-GreenSync","pid":2692386,"thread":2360,"internal_event":"poller_polled","object_id":2420,"t":"2022-03-03T13:09:58.091499Z","queue":"default","locked":2,"priorities":{"2":1,"1":1},"held_locks":[],"newly_locked":[805503883,805503884]}
I, [2022-03-04T00:09:58.092894 #2692386]  INFO -- : Running MyJob - priority: 1
I, [2022-03-04T00:09:58.093421 #2692386]  INFO -- : Running MyJob - priority: 1
I, [2022-03-04T00:09:58.147326 #2692386]  INFO -- : {"lib":"que","hostname":"ZimbiX-GreenSync","pid":2692386,"thread":2360,"internal_event":"poller_polled","object_id":2420,"t":"2022-03-03T13:09:58.147236Z","queue":"default","locked":2,"priorities":{"2":1,"1":1},"held_locks":[],"newly_locked":[805503885,805503886]}
I, [2022-03-04T00:09:58.150473 #2692386]  INFO -- : Running MyJob - priority: 1
I, [2022-03-04T00:09:58.150893 #2692386]  INFO -- : Running MyJob - priority: 1
I, [2022-03-04T00:09:58.202083 #2692386]  INFO -- : {"lib":"que","hostname":"ZimbiX-GreenSync","pid":2692386,"thread":2360,"internal_event":"poller_polled","object_id":2420,"t":"2022-03-03T13:09:58.202014Z","queue":"default","locked":2,"priorities":{"2":1,"1":1},"held_locks":[],"newly_locked":[805503887,805503888]}
I, [2022-03-04T00:09:58.205669 #2692386]  INFO -- : Running MyJob - priority: 1
I, [2022-03-04T00:09:58.205723 #2692386]  INFO -- : Running MyJob - priority: 1
I, [2022-03-04T00:09:58.258079 #2692386]  INFO -- : {"lib":"que","hostname":"ZimbiX-GreenSync","pid":2692386,"thread":2360,"internal_event":"poller_polled","object_id":2420,"t":"2022-03-03T13:09:58.257993Z","queue":"default","locked":1,"priorities":{"2":1,"1":1},"held_locks":[],"newly_locked":[805503889]}
I, [2022-03-04T00:09:58.260309 #2692386]  INFO -- : Running MyJob - priority: 2
I, [2022-03-04T00:09:58.313026 #2692386]  INFO -- : {"lib":"que","hostname":"ZimbiX-GreenSync","pid":2692386,"thread":2360,"internal_event":"poller_polled","object_id":2420,"t":"2022-03-03T13:09:58.312945Z","queue":"default","locked":1,"priorities":{"2":1,"1":1},"held_locks":[],"newly_locked":[805503890]}
I, [2022-03-04T00:09:58.315538 #2692386]  INFO -- : Running MyJob - priority: 2
I, [2022-03-04T00:09:58.366900 #2692386]  INFO -- : {"lib":"que","hostname":"ZimbiX-GreenSync","pid":2692386,"thread":2360,"internal_event":"poller_polled","object_id":2420,"t":"2022-03-03T13:09:58.366867Z","queue":"default","locked":1,"priorities":{"2":1,"1":1},"held_locks":[],"newly_locked":[805503891]}
I, [2022-03-04T00:09:58.368784 #2692386]  INFO -- : Running MyJob - priority: 2
I, [2022-03-04T00:09:58.420966 #2692386]  INFO -- : {"lib":"que","hostname":"ZimbiX-GreenSync","pid":2692386,"thread":2360,"internal_event":"poller_polled","object_id":2420,"t":"2022-03-03T13:09:58.420890Z","queue":"default","locked":1,"priorities":{"2":1,"1":1},"held_locks":[],"newly_locked":[805503892]}
I, [2022-03-04T00:09:58.423198 #2692386]  INFO -- : Running MyJob - priority: 2
I, [2022-03-04T00:09:58.474958 #2692386]  INFO -- : {"lib":"que","hostname":"ZimbiX-GreenSync","pid":2692386,"thread":2360,"internal_event":"poller_polled","object_id":2420,"t":"2022-03-03T13:09:58.474882Z","queue":"default","locked":1,"priorities":{"2":1,"1":1},"held_locks":[],"newly_locked":[805503893]}
I, [2022-03-04T00:09:58.477672 #2692386]  INFO -- : Running MyJob - priority: 2
I, [2022-03-04T00:09:58.529960 #2692386]  INFO -- : {"lib":"que","hostname":"ZimbiX-GreenSync","pid":2692386,"thread":2360,"internal_event":"poller_polled","object_id":2420,"t":"2022-03-03T13:09:58.529878Z","queue":"default","locked":1,"priorities":{"2":1,"1":1},"held_locks":[],"newly_locked":[805503894]}
I, [2022-03-04T00:09:58.532743 #2692386]  INFO -- : Running MyJob - priority: 2
I, [2022-03-04T00:09:58.585029 #2692386]  INFO -- : {"lib":"que","hostname":"ZimbiX-GreenSync","pid":2692386,"thread":2360,"internal_event":"poller_polled","object_id":2420,"t":"2022-03-03T13:09:58.584941Z","queue":"default","locked":1,"priorities":{"2":1,"1":1},"held_locks":[],"newly_locked":[805503895]}
I, [2022-03-04T00:09:58.586900 #2692386]  INFO -- : Running MyJob - priority: 2
I, [2022-03-04T00:09:58.639576 #2692386]  INFO -- : {"lib":"que","hostname":"ZimbiX-GreenSync","pid":2692386,"thread":2360,"internal_event":"poller_polled","object_id":2420,"t":"2022-03-03T13:09:58.639492Z","queue":"default","locked":1,"priorities":{"2":1,"1":1},"held_locks":[],"newly_locked":[805503896]}
I, [2022-03-04T00:09:58.642056 #2692386]  INFO -- : Running MyJob - priority: 2
I, [2022-03-04T00:09:58.694544 #2692386]  INFO -- : {"lib":"que","hostname":"ZimbiX-GreenSync","pid":2692386,"thread":2360,"internal_event":"poller_polled","object_id":2420,"t":"2022-03-03T13:09:58.694449Z","queue":"default","locked":1,"priorities":{"2":1,"1":1},"held_locks":[],"newly_locked":[805503897]}
I, [2022-03-04T00:09:58.697122 #2692386]  INFO -- : Running MyJob - priority: 2
I, [2022-03-04T00:09:58.749006 #2692386]  INFO -- : {"lib":"que","hostname":"ZimbiX-GreenSync","pid":2692386,"thread":2360,"internal_event":"poller_polled","object_id":2420,"t":"2022-03-03T13:09:58.748908Z","queue":"default","locked":1,"priorities":{"2":1,"1":1},"held_locks":[],"newly_locked":[805503898]}
I, [2022-03-04T00:09:58.751463 #2692386]  INFO -- : Running MyJob - priority: 2
I, [2022-03-04T00:09:58.802323 #2692386]  INFO -- : {"lib":"que","hostname":"ZimbiX-GreenSync","pid":2692386,"thread":2360,"internal_event":"poller_polled","object_id":2420,"t":"2022-03-03T13:09:58.802238Z","queue":"default","locked":0,"priorities":{"2":1,"1":1},"held_locks":[],"newly_locked":[]}
I, [2022-03-04T00:10:00.826135 #2692386]  INFO -- : {"lib":"que","hostname":"ZimbiX-GreenSync","pid":2692386,"thread":2360,"internal_event":"poller_polled","object_id":2420,"t":"2022-03-03T13:10:00.826047Z","queue":"default","locked":0,"priorities":{"2":1,"1":1},"held_locks":[],"newly_locked":[]}
I, [2022-03-04T00:10:02.851622 #2692386]  INFO -- : {"lib":"que","hostname":"ZimbiX-GreenSync","pid":2692386,"thread":2360,"internal_event":"poller_polled","object_id":2420,"t":"2022-03-03T13:10:02.851551Z","queue":"default","locked":0,"priorities":{"2":1,"1":1},"held_locks":[],"newly_locked":[]}
I, [2022-03-04T00:10:04.874819 #2692386]  INFO -- : {"lib":"que","hostname":"ZimbiX-GreenSync","pid":2692386,"thread":2360,"internal_event":"poller_polled","object_id":2420,"t":"2022-03-03T13:10:04.874719Z","queue":"default","locked":0,"priorities":{"2":1,"1":1},"held_locks":[],"newly_locked":[]}
^C
```