### PR TITLE
Support job_schema_version 1 for Ruby 2.7 on Que 2.x

### DIFF
--- a/lib/que/job_methods.rb
+++ b/lib/que/job_methods.rb
@@ -48,7 +48,12 @@ module Que
         kwargs = que_target.que_attrs.fetch(:kwargs)
       end
 
-      run(*args, **kwargs)
+      if que_target&.que_attrs&.fetch(:job_schema_version, Que.job_schema_version) == 1
+        run(*args)
+      else
+        run(*args, **kwargs)
+      end
+
       default_resolve_action if que_target && !que_target.que_resolved
     rescue => error
       raise error unless que_target

--- a/lib/que/poller.rb
+++ b/lib/que/poller.rb
@@ -68,7 +68,7 @@ module Que
             SELECT j
             FROM public.que_jobs AS j
             WHERE queue = $1::text
-              AND job_schema_version = #{Que.job_schema_version}
+              AND job_schema_version IN (#{Que.supported_job_schema_versions.join(', ')})
               AND NOT id = ANY($2::bigint[])
               AND priority <= pg_temp.que_highest_remaining_priority($3::jsonb)
               AND run_at <= now()
@@ -89,7 +89,7 @@ module Que
                   SELECT j
                   FROM public.que_jobs AS j
                   WHERE queue = $1::text
-                    AND job_schema_version = #{Que.job_schema_version}
+                    AND job_schema_version IN (#{Que.supported_job_schema_versions.join(', ')})
                     AND NOT id = ANY($2::bigint[])
                     AND priority <= pg_temp.que_highest_remaining_priority(jobs.remaining_priorities)
                     AND run_at <= now()

--- a/lib/que/version.rb
+++ b/lib/que/version.rb
@@ -6,4 +6,12 @@ module Que
   def self.job_schema_version
     2
   end
+
+  def self.supported_job_schema_versions
+    if RUBY_VERSION.start_with?("2")
+      [1, 2]
+    else
+      [2]
+    end
+  end
 end

--- a/spec/que/poller_spec.rb
+++ b/spec/que/poller_spec.rb
@@ -118,6 +118,17 @@ describe Que::Poller do
     assert_equal [one], poll(priorities: {7 => 5})
   end
 
+  it "should skip jobs enqueued with incompatible job_schema_version" do
+    one = DB[:que_jobs].returning(:id).insert(job_class: "Que::Job", job_schema_version: 1).first[:id]
+    two = DB[:que_jobs].returning(:id).insert(job_class: "Que::Job", job_schema_version: Que.job_schema_version).first[:id]
+
+    if RUBY_VERSION.start_with?("2")
+      assert_equal [one, two], poll
+    else
+      assert_equal [two], poll
+    end
+  end
+
   describe "when passed a set of priority requirements" do
     before do
       priorities = []


### PR DESCRIPTION
I have an idea to simplify the v2 migration process so you do not need to run workers for multiple versions of Que simultaneously.

I thought that theoretically if you were running Ruby 2.7 with Que v2.x, you should be able to process jobs enqueued by Que v1.x because Ruby 2.7 is still compatible with legacy Ruby 2 keyword arguments, the behaviour could be the same as running an older Que worker. Thus you would be able to drain all `job_schema_version=1` before upgrading to Ruby 3 very easily. At the same time, any new jobs would be enqueued with `job_schema_version=2`.

I wanted to investigate this a little more so I dove into the code and had a look to see what would be required for such a change.

This code is quite rough as I don't know the Que codebase very well. I've not done a real world test yet, only some simple specs. I've not looked into how this could be supported with listen mode, only polling. I also don't fully understand how the locker works and whether that would need to change also.

I'm keen for some discussion on this idea and some help to get this over the line if it's something we want.