### PR TITLE
[v1.x] Require Ruby < 3 in gemspec

### DIFF
--- a/que.gemspec
+++ b/que.gemspec
@@ -13,6 +13,8 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/que-rb/que'
   spec.license       = 'MIT'
 
+  spec.required_ruby_version = '< 3'
+
   files_to_exclude = [
     /\A\.circleci/,
     /\AGemfile/,


### PR DESCRIPTION
Contributes to https://github.com/que-rb/que/issues/364

After this is merged, we should do a release - I reckon bumping the minor version.