### PR TITLE
Remove assertion that jobs are never nested in the ActiveJob extension

### DIFF
--- a/lib/que/active_job/extensions.rb
+++ b/lib/que/active_job/extensions.rb
@@ -82,11 +82,6 @@ module Que
           # option under the circumstances (doesn't require hacking ActiveJob in
           # any more extensive way).
 
-          # There's no reason this logic should ever nest, because it wouldn't
-          # make sense to run a worker inside of a job, but even so, assert that
-          # nothing absurd is going on.
-          Que.assert NilClass, Thread.current[:que_current_job]
-
           begin
             Thread.current[:que_current_job] = self
 


### PR DESCRIPTION
This assertion is untrue in the Rails ActiveJob tests, and has been overridden in the Rails repo, so it never runs anyway.

@ZimbiX indicated that we should have some discussion about this to figure out the best approach, so I'm mostly just submitting this PR to stimulate the discussion.

This is helpful for me for learning Que in preparation for SofarSolar work :)

Closes https://github.com/greensync/platform-work/issues/451