### PR TITLE
Support DB Version in multi schema environment 

### DIFF
--- a/lib/que/migrations.rb
+++ b/lib/que/migrations.rb
@@ -42,6 +42,7 @@ module Que
             FROM pg_class
             LEFT JOIN pg_description ON pg_description.objoid = pg_class.oid
             WHERE relname = 'que_jobs'
+            ORDER BY pg_class.oid
           SQL
 
         if result.none?


### PR DESCRIPTION
We are using apartment for multi tenancy. We are having issues where this query gives back an inconsistent version because the records that come back from this query do not always have the same order and we are just using the first one. I think ideally this would only look at the public schema, but I figured this was maybe slightly lower touch and would at least improve our situation a fair bit. 