### PR TITLE
Raise when DB schema version comment is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 <!-- MarkdownTOC autolink=true -->
 
+- [Unreleased](#unreleased)
 - [2.1.0 \(2022-08-25\)](#210-2022-08-25)
 - [2.0.0 \(2022-08-25\)](#200-2022-08-25)
 - [1.4.1 \(2022-07-24\)](#141-2022-07-24)
@@ -54,6 +55,18 @@
 - [0.0.1 \(2013-11-07\)](#001-2013-11-07)
 
 <!-- /MarkdownTOC -->
+
+## Unreleased
+
+- **Changed**:
+    + Raises an exception when the Que DB schema version is missing from the database. The migrations system records this version in a comment on the `que_jobs` table. [#379](https://github.com/que-rb/que/pull/379)
+        *   > Que::Error: Cannot determine Que DB schema version.
+            >
+            > The que_jobs table is missing its comment recording the Que DB schema version. This is likely due to a bug in Rails schema dump in Rails 7 versions prior to 7.0.3, omitting comments - see https://github.com/que-rb/que/issues/363. Please determine the appropriate schema version from your migrations and record it manually by running the following SQL (replacing version as appropriate):
+            >
+            > COMMENT ON TABLE que_jobs IS 'version';
+- **Removed**:
+    + Removed support for upgrading directly from a version of Que prior to v0.5.0 (released on 2014-01-14), which introduced the migrations system. It's too difficult to handle the different DB schemas from prior to this.
 
 ## 2.1.0 (2022-08-25)
 

--- a/lib/que/migrations.rb
+++ b/lib/que/migrations.rb
@@ -77,7 +77,7 @@ module Que
         raise Error, <<~ERROR
           Cannot determine Que DB schema version.
 
-          The que_jobs table is abnormally missing its comment recording the Que DB schema version. This is likely due to a bug in Rails schema dump in Rails 7 versions prior to 7.0.3, omitting comments - see https://github.com/que-rb/que/issues/377. Please determine the appropriate schema version from your migrations and record it manually by running the following SQL (replacing version as appropriate):
+          The que_jobs table is abnormally missing its comment recording the Que DB schema version. This is likely due to a bug in Rails schema dump in Rails 7 versions prior to 7.0.3, omitting comments - see https://github.com/que-rb/que/issues/363. Please determine the appropriate schema version from your migrations and record it manually by running the following SQL (replacing version as appropriate):
 
           COMMENT ON TABLE que_jobs IS 'version';
         ERROR

--- a/lib/que/migrations.rb
+++ b/lib/que/migrations.rb
@@ -48,12 +48,39 @@ module Que
           # No table in the database at all.
           0
         elsif (d = result.first[:description]).nil?
-          # There's a table, it was just created before the migration system
-          # existed.
-          1
+          # The table exists but the version comment is missing
+          if _db_schema_matches_db_version_1?
+            1
+          else
+            _raise_db_version_comment_missing_error
+          end
         else
           d.to_i
         end
+      end
+
+      # The que_jobs table could be missing the schema version comment either due to:
+      # - Being created before the migration system existed (matching DB version 1); or
+      # - A bug in Rails schema dump in some versions of Rails
+      # So to determine which is the case, here we check an aspect of the schema that's only like that if just the first migration has been applied
+      def _db_schema_matches_db_version_1?
+        result =
+          Que.execute <<-SQL
+            SELECT column_default AS default_priority
+            FROM information_schema.columns
+            WHERE (table_schema, table_name, column_name) = ('public', 'que_jobs', 'priority');
+          SQL
+        result.first[:default_priority] == '1'
+      end
+
+      def _raise_db_version_comment_missing_error
+        raise Error, <<~ERROR
+          Cannot determine Que DB schema version.
+
+          The que_jobs table is abnormally missing its comment recording the Que DB schema version. This is likely due to a bug in Rails schema dump in Rails 7 versions prior to 7.0.3, omitting comments - see https://github.com/que-rb/que/issues/377. Please determine the appropriate schema version from your migrations and record it manually by running the following SQL (replacing version as appropriate):
+
+          COMMENT ON TABLE que_jobs IS 'version';
+        ERROR
       end
 
       def set_db_version(version)

--- a/lib/que/migrations.rb
+++ b/lib/que/migrations.rb
@@ -49,35 +49,21 @@ module Que
           0
         elsif (d = result.first[:description]).nil?
           # The table exists but the version comment is missing
-          if _db_schema_matches_db_version_1?
-            1
-          else
-            _raise_db_version_comment_missing_error
-          end
+          _raise_db_version_comment_missing_error
         else
           d.to_i
         end
       end
 
       # The que_jobs table could be missing the schema version comment either due to:
-      # - Being created before the migration system existed (matching DB version 1); or
+      # - Being created before the migration system existed; or
       # - A bug in Rails schema dump in some versions of Rails
-      # So to determine which is the case, here we check an aspect of the schema that's only like that if just the first migration has been applied
-      def _db_schema_matches_db_version_1?
-        result =
-          Que.execute <<-SQL
-            SELECT column_default AS default_priority
-            FROM information_schema.columns
-            WHERE (table_schema, table_name, column_name) = ('public', 'que_jobs', 'priority');
-          SQL
-        result.first[:default_priority] == '1'
-      end
-
+      # The former is the case on Que versions prior to v0.5.0 (2014-01-14). Upgrading directly from there is unsupported, so we just raise in all cases of the comment being missing
       def _raise_db_version_comment_missing_error
         raise Error, <<~ERROR
           Cannot determine Que DB schema version.
 
-          The que_jobs table is abnormally missing its comment recording the Que DB schema version. This is likely due to a bug in Rails schema dump in Rails 7 versions prior to 7.0.3, omitting comments - see https://github.com/que-rb/que/issues/363. Please determine the appropriate schema version from your migrations and record it manually by running the following SQL (replacing version as appropriate):
+          The que_jobs table is missing its comment recording the Que DB schema version. This is likely due to a bug in Rails schema dump in Rails 7 versions prior to 7.0.3, omitting comments - see https://github.com/que-rb/que/issues/363. Please determine the appropriate schema version from your migrations and record it manually by running the following SQL (replacing version as appropriate):
 
           COMMENT ON TABLE que_jobs IS 'version';
         ERROR

--- a/spec/que/migrations_spec.rb
+++ b/spec/que/migrations_spec.rb
@@ -74,18 +74,7 @@ describe Que::Migrations do
     assert DB.table_exists?(:que_jobs)
   end
 
-  it "should be able to determine the db version when the que_jobs table was created prior to the existence of the migrations system" do
-    Que.migrate!(version: 0)
-    Que.create!
-    Que.execute("COMMENT ON TABLE que_jobs IS NULL") # Simulate migrations system not existing yet
-    assert_equal 1, Que::Migrations.db_version
-
-    # Clean up.
-    Que::Migrations.migrate!(version: Que::Migrations::CURRENT_VERSION)
-    assert DB.table_exists?(:que_jobs)
-  end
-
-  it "should raise if the db version comment is missing abnormally due to a bug in Rails schema dump" do
+  it "should raise if the db version comment is missing, likely due to a bug in Rails schema dump" do
     Que::Migrations.migrate!(version: Que::Migrations::CURRENT_VERSION)
     Que.execute("COMMENT ON TABLE que_jobs IS NULL") # Simulate bug in Rails schema dump
 


### PR DESCRIPTION
Resolves https://github.com/que-rb/que/issues/377.

[PostgreSQL comment docs](https://www.postgresql.org/docs/current/sql-comment.html)

~~This wasn't as simple as I first thought it'd be, since we also have to cater for the scenario of migrating from before DB schema version was recorded. To detect that case, I'm checking the default for the `priority` column, since that was changed to a much more sensible value in [migration 2](https://github.com/que-rb/que/blob/0cdd37c082443ceef00bdbb10ed5f74b7fe6efbb/lib/que/migrations/2/up.sql).~~

~~I did some code archaeology, and determined that, prior to migration 2, the default for the `priority` column was 1 since https://github.com/que-rb/que/commit/1050850204629958a7c5a7bd5ae0076ce56dd6a2#diff-f5ed5e5d3159a4a7d9d7ea114936cb2147d07e27ce81dcce79c2814e299d2456R8, which (according to the tags that commit appears in) covers way back to v0.1.0. So this is a safe proxy to detect DB schemas pre version 2. However, the `que_jobs` table schema at the linked commit differs from the current [migration 1](https://github.com/que-rb/que/blob/0cdd37c082443ceef00bdbb10ed5f74b7fe6efbb/lib/que/migrations/1/up.sql) - to consider it as schema version 1 and migrate up would produce an incorrect result, if it even works. But regardless, this check against the `priority` column's default preserves the DB schema version 1 detection result as it was before.~~

Migrating when the DB schema version comment is missing now looks like:

```
➜ docker compose up -d db

➜ export DATABASE_URL=postgres://que:que@localhost:5697/que-test

➜ ruby -r bundler/setup -r que -r sequel -e "Que.connection = Sequel.connect(ENV['DATABASE_URL']); Que.migrate!(version: Que::Migrations::CURRENT_VERSION)"

➜ ./auto/psql -c "comment on table que_jobs is null;" 
[+] Running 1/0
 ⠿ Container que-db-1  Running  0.0s
COMMENT

➜ ruby -r bundler/setup -r que -r sequel -e "Que.connection = Sequel.connect(ENV['DATABASE_URL']); Que.migrate!(version: Que::Migrations::CURRENT_VERSION)"
/home/brendan/Projects/que/lib/que/migrations.rb:78:in `_raise_db_version_comment_missing_error': Cannot determine Que DB schema version. (Que::Error)

The que_jobs table is abnormally missing its comment recording the Que DB schema version. This is likely due to a bug in Rails schema dump in Rails 7 versions prior to 7.0.3, omitting comments - see https://github.com/que-rb/que/issues/377. Please determine the appropriate schema version from your migrations and record it manually by running the following SQL (replacing version as appropriate):

COMMENT ON TABLE que_jobs IS 'version';
  from /home/brendan/Projects/que/lib/que/migrations.rb:55:in `db_version'
  from /home/brendan/Projects/que/lib/que/migrations.rb:12:in `block in migrate!'
  from /home/brendan/Projects/que/lib/que/utils/transactions.rb:18:in `block in transaction'
  from /home/brendan/Projects/que/lib/que/connection_pool.rb:39:in `block in checkout'
  from /home/brendan/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/sequel-5.58.0/lib/sequel/connection_pool/threaded.rb:92:in `hold'
  from /home/brendan/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/sequel-5.58.0/lib/sequel/database/connecting.rb:269:in `synchronize'
  from /home/brendan/Projects/que/lib/que/connection_pool.rb:18:in `checkout'
  from /home/brendan/Projects/que/lib/que/utils/transactions.rb:12:in `transaction'
  from /home/brendan/Projects/que/lib/que/migrations.rb:11:in `migrate!'
  from /home/brendan/.rbenv/versions/3.1.2/lib/ruby/3.1.0/forwardable.rb:238:in `migrate!'
  from -e:1:in `<main>'

➜ docker compose down && docker volume rm -f que_db-data
```
