### PR TITLE
Allow library users to check if Que is running via CLI or lib

### DIFF
--- a/lib/que.rb
+++ b/lib/que.rb
@@ -79,6 +79,10 @@ module Que
       @default_queue || DEFAULT_QUEUE
     end
 
+    def server?
+      defined?(Que::CommandLineInterface).nil?
+    end
+
     # Support simple integration with many common connection pools.
     def connection=(conn)
       self.connection_proc =


### PR DESCRIPTION
This follows the sidekiq pattern (i.e. `Sidekiq.server? == true` when running as a worker)
Useful for code to understand if it's running in the `bundle exec que` worker context or not.

Why? 

We'd like to be able to determine within the rails code base (i.e. `config/environment.rb` onwards) if the code is running in the context of the the `que` CLI, or if it's running in the normal rails context. For example, we have some Rails initializers that should run under normal circumstances but not run when running in a Que worker:

```ruby
# config/initializers/custom.rb

if !Que.server?
   # setup up some things
end
```
