### PR TITLE
Add the ability to add arbitrary data to jobs. 

### DIFF
--- a/lib/que/job.rb
+++ b/lib/que/job.rb
@@ -94,13 +94,17 @@ module Que
           end
         end
 
+        tags = job_options[:tags] || []
+        data = { tags: tags }.merge(job_options[:data] || {})
+        # TODO: some protection about overall data size
+
         attrs = {
           queue:    job_options[:queue]    || resolve_que_setting(:queue) || Que.default_queue,
           priority: job_options[:priority] || resolve_que_setting(:priority),
           run_at:   job_options[:run_at]   || resolve_que_setting(:run_at),
           args:     args,
           kwargs:   kwargs,
-          data:     job_options[:tags] ? { tags: job_options[:tags] } : {},
+          data:     data,
           job_class: \
             job_options[:job_class] || name ||
               raise(Error, "Can't enqueue an anonymous subclass of Que::Job"),


### PR DESCRIPTION
This is a bit of a speculative PR.. not sure of it's impact - it could be abused and I think the implementation would definitely need some checks on payload size, etc. 

That said, it could be very useful for trace context propogation and prevent hacks we see here like https://github.com/open-telemetry/opentelemetry-ruby-contrib/blob/main/instrumentation/que/lib/opentelemetry/instrumentation/que/patches/que_job.rb#L26-L39

If you think it's a good idea I'll finish the implementation, and write some tests.