### PR TITLE
fix(SynchronousJobs) Fix synchronous jobs return value

### DIFF
--- a/lib/que/job.rb
+++ b/lib/que/job.rb
@@ -246,6 +246,7 @@ module Que
         new(attrs).tap do |job|
           Que.run_job_middleware(job) do
             job._run(reraise_errors: true)
+            job
           end
         end
       end


### PR DESCRIPTION
# Context

* We use `Que` in my company as one of a few queue providers to manage jobs in different services through a custom framework abstracting its usage
* For testing purposes, we use `Que` in synchronous mode
* We stumbled upon an issue where failed synchronous jobs were raising unexpected errors when trying to gather metrics and logs about their status, whereas it was working perfectly fine in normal production (asynchronous) state

![Screenshot 2023-03-31 at 14 00 06](https://user-images.githubusercontent.com/1598346/229114634-27d14743-2c1c-4a93-86d9-018b676a2e24.png)


The PR aims at fixing this issue without the boilerplate in our codebase to mitigate this issue which exists just during testing.

# Description
   * Asynchronous jobs return themselves once ran
   * Synchronous jobs return the result of their call

This PR makes both calls returning the same thing, which is the job itself.