### PR TITLE
Don't clear ActiveRecord connections when run_synchronously is enabled

### DIFF
--- a/lib/que/active_record/connection.rb
+++ b/lib/que/active_record/connection.rb
@@ -42,7 +42,7 @@ module Que
             # feature to unknowingly leak connections to other databases. So,
             # take the additional step of telling ActiveRecord to check in all
             # of the current thread's connections after each job is run.
-            ::ActiveRecord::Base.clear_active_connections!
+            ::ActiveRecord::Base.clear_active_connections! unless job.class.resolve_que_setting(:run_synchronously)
           end
         end
       end

--- a/spec/que/active_record/connection_spec.rb
+++ b/spec/que/active_record/connection_spec.rb
@@ -34,9 +34,7 @@ if defined?(::ActiveRecord)
   describe Que::ActiveRecord::Connection::JobMiddleware do
     before do
       Que.connection = ::ActiveRecord
-    end
 
-    it "should clear connections to secondary DBs between jobs" do
       class SecondDatabaseModel < ActiveRecord::Base
         establish_connection(QUE_URL)
       end
@@ -49,10 +47,20 @@ if defined?(::ActiveRecord)
           SecondDatabaseModel.connection.execute("SELECT 1")
         end
       end
+    end
 
+    it "should clear connections to secondary DBs between jobs" do
       SecondDatabaseModelJob.run
 
       refute SecondDatabaseModel.connection_handler.active_connections?
+    end
+
+
+    it "shouldn't clear connections to secondary DBs between jobs if run_synchronously is enabled " do
+      Que::Job.run_synchronously = true
+      SecondDatabaseModelJob.run
+
+      assert SecondDatabaseModel.connection_handler.active_connections?
     end
   end
 end


### PR DESCRIPTION
Clearing active connection in `run_synchronously` mode can lead to unexpected behaviour, especially when executed within a database transaction.

Aa a result a connection with active transaction can be released back to the pool and picked up by another thread.

Have a look at the following simplified code snippet that illustrates the issue:

```ruby
Que::Job.run_synchronously = true

ActiveRecord::Base.transaction do
  ActiveRecord::Base.connection_pool.active_connection? # true
  ActiveRecord::Base.connection.transaction_open? # true
  # ^ we have an active connection and are currently within a DB transaction

  SomeQueJob.enqueue(...)
  # ^ the job runs synchronously and calls ::ActiveRecord::Base.clear_active_connections!

  ActiveRecord::Base.connection_pool.active_connection? # nil
  # ^ our connection with open transaction got returned back to the pool
  
  # someone (possibly another thread) picks up a connection back from the pool
  ActiveRecord::Base.connection

  ActiveRecord::Base.connection_pool.active_connection? # true
  ActiveRecord::Base.connection.transaction_open? # true
  # ^ it's the same connection with the previously opened transaction
end
```