### PR TITLE
Improve `QueJob#by_job_class` performance.

### DIFF
--- a/lib/que/active_record/model.rb
+++ b/lib/que/active_record/model.rb
@@ -25,9 +25,10 @@ module Que
       class << self
         def by_job_class(job_class)
           job_class = job_class.name if job_class.is_a?(Class)
+          job_class_doc = "[{\"job_class\": \"#{job_class}\"}]"
           where(
-            "que_jobs.job_class = ? OR (que_jobs.job_class = 'ActiveJob::QueueAdapters::QueAdapter::JobWrapper' AND que_jobs.args->0->>'job_class' = ?)",
-            job_class, job_class,
+            "que_jobs.job_class = ? OR (que_jobs.job_class = 'ActiveJob::QueueAdapters::QueAdapter::JobWrapper' AND que_jobs.args @> ?)",
+            job_class, job_class_doc,
           )
         end
 


### PR DESCRIPTION
This method wasn't making use of the `que_jobs.args` index and was performing badly on large datasets.

GIN indexes don't support the `=` operator, but support existence `?` and containment `@>` among others. To make use of the index the query has to check for containment of a subset document rather than match a value within the document directly.

`QueJob#by_job_args` is already querying in this way; this change makes `QueJob#by_job_class` consistent with it.

Context:

https://www.postgresql.org/docs/9.6/datatype-json.html#JSON-INDEXING

Given a jsonb column "data" indexed as follows:
```sql
CREATE INDEX data_index ON table USING GIN (data);
```

And with data in this format:
```json
{
  "name": "Melbourne",
  "type": "City"
}
```

This query will make use of the index:
```sql
SELECT data FROM table WHERE data @> '{"name": "Melbourne"}';
```

But this one will not:
```sql
SELECT data FROM table WHERE data->>'name' = "Melbourne";
```