### PR TITLE
Fix specificity of Rails versions in spec gemfiles

### DIFF
--- a/spec/gemfiles/Gemfile-rails-6.0
+++ b/spec/gemfiles/Gemfile-rails-6.0
@@ -5,8 +5,8 @@ gem 'que', path: '../..'
 group :development, :test do
   gem 'rake'
 
-  gem 'activerecord',    '~> 6.0', require: nil
-  gem 'activejob',       '~> 6.0', require: nil
+  gem 'activerecord',    '~> 6.0.0', require: nil
+  gem 'activejob',       '~> 6.0.0', require: nil
   gem 'sequel',          require: nil
   gem 'connection_pool', require: nil
   gem 'pond',            require: nil

--- a/spec/gemfiles/Gemfile-rails-6.1
+++ b/spec/gemfiles/Gemfile-rails-6.1
@@ -5,8 +5,8 @@ gem 'que', path: '../..'
 group :development, :test do
   gem 'rake'
 
-  gem 'activerecord',    '~> 6.1', require: nil
-  gem 'activejob',       '~> 6.1', require: nil
+  gem 'activerecord',    '~> 6.1.0', require: nil
+  gem 'activejob',       '~> 6.1.0', require: nil
   gem 'sequel',          require: nil
   gem 'connection_pool', require: nil
   gem 'pond',            require: nil

--- a/spec/gemfiles/Gemfile-rails-7.0
+++ b/spec/gemfiles/Gemfile-rails-7.0
@@ -5,8 +5,8 @@ gem 'que', path: '../..'
 group :development, :test do
   gem 'rake'
 
-  gem 'activerecord',    '~> 7.0', require: nil
-  gem 'activejob',       '~> 7.0', require: nil
+  gem 'activerecord',    '~> 7.0.0', require: nil
+  gem 'activejob',       '~> 7.0.0', require: nil
   gem 'sequel',          require: nil
   gem 'connection_pool', require: nil
   gem 'pond',            require: nil


### PR DESCRIPTION
The Gemfile that's supposed to test Rails 7.0 was running Rails 7.1 🤦

Issue discovered via [Que's Rails 7.0 tests running for](https://github.com/que-rb/que/actions/runs/6456183723/job/17525155590?pr=401#step:5:87) https://github.com/que-rb/que/pull/401 saying:

```
Installing activejob 7.1.0
```