### PR TITLE
Support Rails 7.1+ by adding ActiveJob Que adapter removed from Rails

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,16 +8,16 @@ jobs:
     strategy:
       matrix:
         ruby_version: ['2.7', '3.0', '3.1', '3.2']
-        rails_gemfile: ['6.0', '6.1', '7.0']
+        rails_gemfile: ['6.0', '6.1', '7.0', '7.1']
         postgres_version: ['14']
         include:
         # Postgres versions
-        - { ruby_version: '3.2', rails_gemfile: '7.0', postgres_version: '9' }
-        - { ruby_version: '3.2', rails_gemfile: '7.0', postgres_version: '10' }
-        - { ruby_version: '3.2', rails_gemfile: '7.0', postgres_version: '11' }
-        - { ruby_version: '3.2', rails_gemfile: '7.0', postgres_version: '12' }
-        - { ruby_version: '3.2', rails_gemfile: '7.0', postgres_version: '13' }
-        - { ruby_version: '3.2', rails_gemfile: '7.0', postgres_version: '14' }
+        - { ruby_version: '3.2', rails_gemfile: '7.1', postgres_version: '9' }
+        - { ruby_version: '3.2', rails_gemfile: '7.1', postgres_version: '10' }
+        - { ruby_version: '3.2', rails_gemfile: '7.1', postgres_version: '11' }
+        - { ruby_version: '3.2', rails_gemfile: '7.1', postgres_version: '12' }
+        - { ruby_version: '3.2', rails_gemfile: '7.1', postgres_version: '13' }
+        - { ruby_version: '3.2', rails_gemfile: '7.1', postgres_version: '14' }
         exclude: []
     name: "Test: Ruby ${{ matrix.ruby_version }}, Rails ${{ matrix.rails_gemfile }}, PostgreSQL ${{ matrix.postgres_version }}"
     services:

--- a/Gemfile
+++ b/Gemfile
@@ -6,8 +6,8 @@ source 'https://rubygems.org'
 group :development, :test do
   gem 'rake'
 
-  gem 'activerecord',    '~> 6.0', require: nil
-  gem 'activejob',       '~> 6.0', require: nil
+  gem 'activerecord',    '~> 7.1.0', require: nil
+  gem 'activejob',       '~> 7.1.0', require: nil
   gem 'sequel',          require: nil
   gem 'connection_pool', require: nil
   gem 'pond',            require: nil

--- a/lib/que/active_job/extensions.rb
+++ b/lib/que/active_job/extensions.rb
@@ -119,38 +119,19 @@ if ActiveJob.gem_version >= Gem::Version.new('7.1')
       class QueAdapter
         def enqueue(job)
           job_options = { priority: job.priority, queue: job.queue_name }
-          que_job = nil
-
-          if require_job_options_kwarg?
-            que_job = JobWrapper.enqueue job.serialize, job_options: job_options
-          else
-            que_job = JobWrapper.enqueue job.serialize, **job_options
-          end
-
+          que_job = JobWrapper.enqueue job.serialize, **job_options
           job.provider_job_id = que_job.attrs["job_id"]
           que_job
         end
 
         def enqueue_at(job, timestamp)
           job_options = { priority: job.priority, queue: job.queue_name, run_at: Time.at(timestamp) }
-          que_job = nil
-
-          if require_job_options_kwarg?
-            que_job = JobWrapper.enqueue job.serialize, job_options: job_options
-          else
-            que_job = JobWrapper.enqueue job.serialize, **job_options
-          end
-
+          que_job = JobWrapper.enqueue job.serialize, **job_options
           job.provider_job_id = que_job.attrs["job_id"]
           que_job
         end
 
         private
-
-        def require_job_options_kwarg?
-          @require_job_options_kwarg ||=
-            JobWrapper.method(:enqueue).parameters.any? { |ptype, pname| ptype == :key && pname == :job_options }
-        end
 
         class JobWrapper < Que::Job
           def run(job_data)

--- a/spec/gemfiles/Gemfile-rails-7.1
+++ b/spec/gemfiles/Gemfile-rails-7.1
@@ -1,0 +1,23 @@
+source 'https://rubygems.org'
+
+gem 'que', path: '../..'
+
+group :development, :test do
+  gem 'rake'
+
+  gem 'activerecord',    '~> 7.1.0', require: nil
+  gem 'activejob',       '~> 7.1.0', require: nil
+  gem 'sequel',          require: nil
+  gem 'connection_pool', require: nil
+  gem 'pond',            require: nil
+  gem 'pg',              require: nil, platform: :ruby
+  gem 'pg_jruby',        require: nil, platform: :jruby
+end
+
+group :test do
+  gem 'minitest',         '~> 5.10.1'
+  gem 'minitest-profile', '0.0.2'
+  gem 'minitest-hooks',   '1.4.0'
+  gem 'pry'
+  gem 'pg_examiner', '~> 0.5.2'
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,8 @@
 # Silence Ruby warnings.
 $VERBOSE = nil
 
+require 'que'
+
 # ActiveRecord and ActiveJob require ActiveSupport, which affects a bunch of
 # core classes and may change some behavior that we rely on, so only bring it in
 # in some spec runs.
@@ -10,13 +12,11 @@ if ENV['USE_RAILS'] == 'true'
   require 'active_record'
   require 'active_job'
 
+  require 'que/active_job/extensions'
+
   ActiveJob::Base.queue_adapter = :que
   ActiveJob::Base.logger = nil
-
-  # require 'que/active_job/extensions'
 end
-
-require 'que'
 
 # Libraries necessary for tests.
 require 'uri'


### PR DESCRIPTION
ActiveJob's Que adapter was removed from Rails in https://github.com/rails/rails/pull/46005 (issue: https://github.com/rails/rails/issues/45899). This is a good thing for simplicity - Que and ActiveJob won't have to keep patching over each other's changes. But it's unfortunately broken Que in Rails.

Sorry, I didn't realise this would be an issue in removing the Que adapter from Rails! 😬 I really should have tested that before giving the go ahead.

The adapter is still necessary, and so this PR incorporates it into Que.

I'd thought we'd need to now use `ActiveJob::Base.queue_adapter = ActiveJob::QueueAdapters::QueAdapter.new` rather than `ActiveJob::Base.queue_adapter = :que`, but it seems that by keeping the adapter class namespace unchanged, we can still use the latter. We have to keep it unchanged for backwards compatibility, as the class name of `ActiveJob::QueueAdapters::QueAdapter::JobWrapper` must remain the same, given this string would be in old job records in the database.

Because the class name needs to remain the same, but we still need to support older versions of ActiveJob where that class exists there, I've defined the adapter here only when the version of ActiveJob is 7.1+.

I was able to simplify the adapter slightly by removing `#require_job_options_kwarg?`, since the Que codebase only has to cater for one version of Que =P

I considered removing & inlining `Que::ActiveJob::WrapperExtensions::ClassMethods#enqueue` into our Rails 7.1+ QueAdapter, but it still needs to exist in place to support older versions of Rails =\ Keeping it in place conditionally based on the Rails version would be [a bit complex](https://github.com/que-rb/que/issues/399#issuecomment-1725170442), and so perhaps not an improvement.

Supersedes https://github.com/que-rb/que/pull/401.