### PR TITLE
Temporarily restict rails version to 7.1.0 for 7.1 tests

### DIFF
--- a/spec/gemfiles/Gemfile-rails-7.1
+++ b/spec/gemfiles/Gemfile-rails-7.1
@@ -5,8 +5,8 @@ gem 'que', path: '../..'
 group :development, :test do
   gem 'rake'
 
-  gem 'activerecord',    '~> 7.1.0', require: nil
-  gem 'activejob',       '~> 7.1.0', require: nil
+  gem 'activerecord',    '7.1.0', require: nil # 7.1.1 breaks pg 9.x support, change this when 7.1.2 is released
+  gem 'activejob',       '7.1.0', require: nil # 7.1.1 breaks pg 9.x support, change this when 7.1.2 is released
   gem 'sequel',          require: nil
   gem 'connection_pool', require: nil
   gem 'pond',            require: nil


### PR DESCRIPTION
Looks like [this PR](https://github.com/rails/rails/pull/49504) breaks postgres 9 support.

Fixed by [this PR](https://github.com/rails/rails/pull/49598) so we can be less restrictive with the version of rails when that is released.