### PR TITLE
Update clear_active_connections! to resolve deprecation warning in activerecord 7.1

### DIFF
--- a/lib/que/active_record/connection.rb
+++ b/lib/que/active_record/connection.rb
@@ -42,7 +42,7 @@ module Que
             # feature to unknowingly leak connections to other databases. So,
             # take the additional step of telling ActiveRecord to check in all
             # of the current thread's connections after each job is run.
-            ::ActiveRecord::Base.clear_active_connections! unless job.class.resolve_que_setting(:run_synchronously)
+            ::ActiveRecord::Base.connection_handler.clear_active_connections! unless job.class.resolve_que_setting(:run_synchronously)
           end
         end
       end

--- a/spec/que/active_record/connection_spec.rb
+++ b/spec/que/active_record/connection_spec.rb
@@ -39,7 +39,7 @@ if defined?(::ActiveRecord)
         establish_connection(QUE_URL)
       end
 
-      SecondDatabaseModel.clear_active_connections!
+      SecondDatabaseModel.connection_handler.clear_active_connections!
       refute SecondDatabaseModel.connection_handler.active_connections?
 
       class SecondDatabaseModelJob < Que::Job


### PR DESCRIPTION
With `activerecord (= 7.1.1)`, the following deprecation warning is received on master:


```
DEPRECATION WARNING: Calling `ActiveRecord::Base.clear_active_connections! is deprecated. Please call the method directly on the connection handler; for example: `ActiveRecord::Base.connection_handler.clear_active_connections!`
```

This PR replaces the call to `ActiveRecord::Base.clear_active_connections!` with the now recommended method `ActiveRecord::Base.connection_handler.clear_active_connections!`. This change ensures compatibility with future versions of ActiveRecord and follows current recommendations.