### PR TITLE
Fixes #411 Wrap job invocation in Rails executor when using ActiveRecord

### DIFF
--- a/lib/que/active_record/connection.rb
+++ b/lib/que/active_record/connection.rb
@@ -2,27 +2,29 @@
 
 module Que
   module ActiveRecord
+    class << self
+      # Use Rails' executor (if present) to make sure that the connection
+      # we're using isn't taken from us while the block runs. See
+      # https://github.com/que-rb/que/issues/166#issuecomment-274218910
+      def wrap_in_rails_executor(&block)
+        if defined?(::Rails.application.executor)
+          ::Rails.application.executor.wrap(&block)
+        else
+          yield
+        end
+      end
+    end
+
     module Connection
       class << self
         private
 
         # Check out a PG::Connection object from ActiveRecord's pool.
         def checkout
-          wrap_in_rails_executor do
+          Que::ActiveRecord.wrap_in_rails_executor do
             ::ActiveRecord::Base.connection_pool.with_connection do |conn|
                yield conn.raw_connection
             end
-          end
-        end
-
-        # Use Rails' executor (if present) to make sure that the connection
-        # we're using isn't taken from us while the block runs. See
-        # https://github.com/que-rb/que/issues/166#issuecomment-274218910
-        def wrap_in_rails_executor(&block)
-          if defined?(::Rails.application.executor)
-            ::Rails.application.executor.wrap(&block)
-          else
-            yield
           end
         end
       end
@@ -30,7 +32,9 @@ module Que
       module JobMiddleware
         class << self
           def call(job)
-            yield
+            Que::ActiveRecord.wrap_in_rails_executor do
+              yield
+            end
 
             # ActiveRecord will check out connections to the current thread when
             # queries are executed and not return them to the pool until


### PR DESCRIPTION
See #411 first.

The connection is being released by que, because `Rails.application.executor` has [this](https://github.com/rails/rails/blob/f6f6b0542fd9ae6aebe3529baba358d521d64638/activerecord/lib/active_record/query_cache.rb#L36) callback registered, being called [here](https://github.com/rails/rails/blob/f6f6b0542fd9ae6aebe3529baba358d521d64638/activesupport/lib/active_support/execution_wrapper.rb#L96C20-L96C20).

A smaller reproducible example is here:
```ruby
class TestQueJob < Que::Job
  def run(id)
    conn = ::ActiveRecord::Base.connection

    Que.pool.execute("SELECT 1;")
    
    if conn != ::ActiveRecord::Base.connection
      raise "Connection changed"
    end
  end
end
```

I think que should be executing the entire job code inside of `Rails.application.executor`, then the nested one in connection would be a noop and the connection would only be released after the whole job is finished.

That would follow the Rails guidelines for writing libraries here https://guides.rubyonrails.org/v7.1/threading_and_code_execution.html#wrapping-application-code
> If you're writing a library or component that will invoke application code, you should wrap it with a call to the executor