### PR TITLE
update readme with link to Que::View

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ There are a couple ways to do testing. You may want to set `Que::Job.run_synchro
 These projects are tested to be compatible with Que 1.x:
 
 - [que-web](https://github.com/statianzo/que-web) is a Sinatra-based UI for inspecting your job queue.
+- [que-view](https://github.com/kortirso/que-view) is a Rails engine-based UI for inspecting your job queue.
 - [que-scheduler](https://github.com/hlascelles/que-scheduler) lets you schedule tasks using a cron style config file.
 - [que-locks](https://github.com/airhorns/que-locks) lets you lock around job execution for so only one job runs at once for a set of arguments.
 - [que-unique](https://github.com/bambooengineering/que-unique) provides fast in-memory `enqueue` deduping.


### PR DESCRIPTION
I'd like to introduce Que::View Rails engine for using instead of Que::Web for UI

With this engine the number of dependencies is reduced compared to Que::Web, no more Sinatra, jQuery, some redundant styles and js, and looks like Que::Web was updated 2 years ago last time

Que::View has additional features:
- processes metrics
- queue metrics

@nickburgin @ZimbiX @siegy22 what do you think?