### PR TITLE
Fix bundler in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,7 +45,7 @@ jobs:
       run: |
         sudo apt-get -yqq install libpq-dev postgresql-client
         createdb que-test
-        gem install bundler
+        gem install bundler --version '~> 2.4.22'
         bundle install --jobs 4 --retry 3
         USE_RAILS=true bundle exec rake test
         bundle exec rake test

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update \
   && apt-get install -y libpq-dev \
   && rm -rf /var/lib/apt/lists/*
 
-ENV RUBY_BUNDLER_VERSION 2.3.7
+ENV RUBY_BUNDLER_VERSION 2.4.22
 RUN gem install bundler -v $RUBY_BUNDLER_VERSION
 
 ENV BUNDLE_PATH /usr/local/bundle


### PR DESCRIPTION
[Bundler 2.5 dropped support for Ruby 2.7](https://github.com/rubygems/rubygems/releases/tag/bundler-v2.5.0). Since we are testing with Ruby 2.7, we should pin the version of Bundler to 2.4.x since this is the last version that's compatible with 2.7.