### PR TITLE
Fix activerecord 7.1 and 7.2 deprecations

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,17 +8,21 @@ jobs:
     strategy:
       matrix:
         ruby_version: ['2.7', '3.0', '3.1', '3.2']
-        rails_gemfile: ['6.0', '6.1', '7.0', '7.1']
+        rails_gemfile: ['6.0', '6.1', '7.0', '7.1', '7.2']
         postgres_version: ['14']
         include:
         # Postgres versions
-        - { ruby_version: '3.2', rails_gemfile: '7.1', postgres_version: '9' }
-        - { ruby_version: '3.2', rails_gemfile: '7.1', postgres_version: '10' }
-        - { ruby_version: '3.2', rails_gemfile: '7.1', postgres_version: '11' }
-        - { ruby_version: '3.2', rails_gemfile: '7.1', postgres_version: '12' }
-        - { ruby_version: '3.2', rails_gemfile: '7.1', postgres_version: '13' }
-        - { ruby_version: '3.2', rails_gemfile: '7.1', postgres_version: '14' }
-        exclude: []
+        - { ruby_version: '3.2', rails_gemfile: '7.2', postgres_version: '9' }
+        - { ruby_version: '3.2', rails_gemfile: '7.2', postgres_version: '10' }
+        - { ruby_version: '3.2', rails_gemfile: '7.2', postgres_version: '11' }
+        - { ruby_version: '3.2', rails_gemfile: '7.2', postgres_version: '12' }
+        - { ruby_version: '3.2', rails_gemfile: '7.2', postgres_version: '13' }
+        - { ruby_version: '3.2', rails_gemfile: '7.2', postgres_version: '14' }
+        exclude: # Rails 7.2 is not compatible with Ruby < 3.1
+        - ruby_version: '2.7'
+          rails_gemfile: '7.2'
+        - ruby_version: '3.0'
+          rails_gemfile: '7.2'
     name: "Test: Ruby ${{ matrix.ruby_version }}, Rails ${{ matrix.rails_gemfile }}, PostgreSQL ${{ matrix.postgres_version }}"
     services:
       db:

--- a/lib/que/active_record/connection.rb
+++ b/lib/que/active_record/connection.rb
@@ -42,7 +42,12 @@ module Que
             # feature to unknowingly leak connections to other databases. So,
             # take the additional step of telling ActiveRecord to check in all
             # of the current thread's connections after each job is run.
-            ::ActiveRecord::Base.clear_active_connections! unless job.class.resolve_que_setting(:run_synchronously)
+            return if job.class.resolve_que_setting(:run_synchronously)
+            if ::ActiveRecord.version >= Gem::Version.new('7.1')
+              ::ActiveRecord::Base.connection_handler.clear_active_connections!(:all)
+            else
+              ::ActiveRecord::Base.clear_active_connections!
+            end
           end
         end
       end

--- a/spec/gemfiles/Gemfile-rails-7.2
+++ b/spec/gemfiles/Gemfile-rails-7.2
@@ -1,7 +1,6 @@
-# When adding/changing anything in this file, remember to update the alternate
-# Gemfiles in spec/gemfiles as well!
-
 source 'https://rubygems.org'
+
+gem 'que', path: '../..'
 
 group :development, :test do
   gem 'rake'
@@ -11,21 +10,14 @@ group :development, :test do
   gem 'sequel',          require: nil
   gem 'connection_pool', require: nil
   gem 'pond',            require: nil
-
-  gem 'pg',       require: nil, platform: :ruby
-  gem 'jruby-pg', require: nil, platform: :jruby
+  gem 'pg',              require: nil, platform: :ruby
+  gem 'pg_jruby',        require: nil, platform: :jruby
 end
 
 group :test do
   gem 'minitest',         '~> 5.10.1'
   gem 'minitest-profile', '0.0.2'
   gem 'minitest-hooks',   '1.4.0'
-  gem 'minitest-fail-fast', '0.1.0'
-
-  gem 'm'
-
   gem 'pry'
   gem 'pg_examiner', '~> 0.5.2'
 end
-
-gemspec

--- a/spec/que/active_record/connection_spec.rb
+++ b/spec/que/active_record/connection_spec.rb
@@ -39,7 +39,11 @@ if defined?(::ActiveRecord)
         establish_connection(QUE_URL)
       end
 
-      SecondDatabaseModel.clear_active_connections!
+      if ::ActiveRecord.version >= Gem::Version.new('7.1')
+        SecondDatabaseModel.connection_handler.clear_active_connections!(:all)
+      else
+        SecondDatabaseModel.clear_active_connections!
+      end
       refute SecondDatabaseModel.connection_handler.active_connections?
 
       class SecondDatabaseModelJob < Que::Job


### PR DESCRIPTION
Similar to https://github.com/que-rb/que/pull/407, but fixes 2 related deprecation warnings and adds backward-compatibility with older version of rails.

On rails 7.1 these are deprecation warnings.

On rails 7.2 the second one is not a warning anymore but a crash with `undefined method clear_active_connections!'`

---

Fixes the following:

<code>DEPRECATION WARNING: Calling `ActiveRecord::Base.clear_active_connections! is deprecated. Please call the method directly on the connection handler; for example: `ActiveRecord::Base.connection_handler.clear_active_connections!`. (called from call at /app/.bundle/ruby/3.2.0/bundler/gems/shoryuken-869fb0c77f8e/lib/shoryuken/middleware/server/active_record.rb:8)</code>

<code>DEPRECATION WARNING: `clear_active_connections!` currently only applies to connection pools in the current role (`writing`). In Rails 7.2, this method will apply to all known pools, regardless of role. To affect only those connections belonging to a specific role, pass the role name as an argument. To switch to the new behavior, pass `:all` as the role name. (called from call at /app/.bundle/ruby/3.2.0/bundler/gems/shoryuken-869fb0c77f8e/lib/shoryuken/middleware/server/active_record.rb:8)</code>
