### PR TITLE
Introduce poll-interval-variance option

### DIFF
--- a/lib/que/command_line_interface.rb
+++ b/lib/que/command_line_interface.rb
@@ -18,14 +18,15 @@ module Que
         default_require_file: RAILS_ENVIRONMENT_FILE
       )
 
-        options           = {}
-        queues            = []
-        log_level         = 'info'
-        log_internals     = false
-        poll_interval     = 5
-        connection_url    = nil
-        worker_count      = nil
-        worker_priorities = nil
+        options                = {}
+        queues                 = []
+        log_level              = 'info'
+        log_internals          = false
+        poll_interval          = 5
+        poll_interval_variance = 0
+        connection_url         = nil
+        worker_count           = nil
+        worker_priorities      = nil
 
         parser =
           OptionParser.new do |opts|
@@ -48,6 +49,15 @@ module Que
                 "in seconds (default: 5)",
             ) do |i|
               poll_interval = i
+            end
+
+            opts.on(
+              '-j',
+              '--poll-interval-variance [INTERVAL]',
+              Float,
+              "Set maximum variance in poll interval, in seconds (default: 0)",
+            ) do |j|
+              poll_interval_variance = j.to_f
             end
 
             opts.on(
@@ -232,7 +242,8 @@ OUTPUT
           options[:queues] = queues_hash
         end
 
-        options[:poll_interval] = poll_interval
+        options[:poll_interval]          = poll_interval
+        options[:poll_interval_variance] = poll_interval_variance
 
         locker =
           begin

--- a/lib/que/locker.rb
+++ b/lib/que/locker.rb
@@ -33,7 +33,7 @@ module Que
     }
 
   class Locker
-    attr_reader :thread, :workers, :job_buffer, :locks, :queues, :poll_interval
+    attr_reader :thread, :workers, :job_buffer, :locks, :queues, :poll_interval, :poll_interval_variance
 
     MESSAGE_RESOLVERS = {}
     RESULT_RESOLVERS  = {}
@@ -47,22 +47,24 @@ module Que
     RESULT_RESOLVERS[:job_finished] =
       -> (messages) { finish_jobs(messages.map{|m| m.fetch(:metajob)}) }
 
-    DEFAULT_POLL_INTERVAL       = 5.0
-    DEFAULT_WAIT_PERIOD         = 50
-    DEFAULT_MAXIMUM_BUFFER_SIZE = 8
-    DEFAULT_WORKER_PRIORITIES   = [10, 30, 50, nil, nil, nil].freeze
+    DEFAULT_POLL_INTERVAL          = 5.0
+    DEFAULT_POLL_INTERVAL_VARIANCE = 0.0
+    DEFAULT_WAIT_PERIOD            = 50
+    DEFAULT_MAXIMUM_BUFFER_SIZE    = 8
+    DEFAULT_WORKER_PRIORITIES      = [10, 30, 50, nil, nil, nil].freeze
 
     def initialize(
-      queues:              [Que.default_queue],
-      connection_url:      nil,
-      listen:              true,
-      poll:                true,
-      poll_interval:       DEFAULT_POLL_INTERVAL,
-      wait_period:         DEFAULT_WAIT_PERIOD,
-      maximum_buffer_size: DEFAULT_MAXIMUM_BUFFER_SIZE,
-      worker_priorities:   DEFAULT_WORKER_PRIORITIES,
-      on_worker_start:     nil,
-      pidfile:             nil
+      queues:                 [Que.default_queue],
+      connection_url:         nil,
+      listen:                 true,
+      poll:                   true,
+      poll_interval:          DEFAULT_POLL_INTERVAL,
+      poll_interval_variance: DEFAULT_POLL_INTERVAL_VARIANCE,
+      wait_period:            DEFAULT_WAIT_PERIOD,
+      maximum_buffer_size:    DEFAULT_MAXIMUM_BUFFER_SIZE,
+      worker_priorities:      DEFAULT_WORKER_PRIORITIES,
+      on_worker_start:        nil,
+      pidfile:                nil
     )
 
       # Sanity-check all our arguments, since some users may instantiate Locker
@@ -71,6 +73,7 @@ module Que
       Que.assert [TrueClass, FalseClass], poll
 
       Que.assert Numeric, poll_interval
+      Que.assert Numeric, poll_interval_variance
       Que.assert Numeric, wait_period
 
       Que.assert Array, worker_priorities
@@ -94,13 +97,14 @@ module Que
 
       Que.internal_log :locker_instantiate, self do
         {
-          queues:              queues,
-          listen:              listen,
-          poll:                poll,
-          poll_interval:       poll_interval,
-          wait_period:         wait_period,
-          maximum_buffer_size: maximum_buffer_size,
-          worker_priorities:   worker_priorities,
+          queues:                 queues,
+          listen:                 listen,
+          poll:                   poll,
+          poll_interval:          poll_interval,
+          poll_interval_variance: poll_interval_variance,
+          wait_period:            wait_period,
+          maximum_buffer_size:    maximum_buffer_size,
+          worker_priorities:      worker_priorities,
         }
       end
 
@@ -108,6 +112,7 @@ module Que
       @locks = Set.new
 
       @poll_interval = poll_interval
+      @poll_interval_variance = poll_interval_variance
 
       if queues.is_a?(Hash)
         @queue_names = queues.keys
@@ -207,6 +212,7 @@ module Que
                     connection:    @connection,
                     queue:         queue_name,
                     poll_interval: interval,
+                    poll_interval_variance: poll_interval_variance,
                   )
                 end
               end

--- a/spec/que/command_line_interface_spec.rb
+++ b/spec/que/command_line_interface_spec.rb
@@ -188,6 +188,7 @@ MSG
     def assert_locker_instantiated(
       worker_priorities: [10, 30, 50, nil, nil, nil],
       poll_interval: 5,
+      poll_interval_variance: 0.0,
       listen: true,
       wait_period: 50,
       queues: ['default'],
@@ -199,13 +200,14 @@ MSG
 
       locker_instantiate = locker_instantiates.first
 
-      assert_equal listen,              locker_instantiate[:listen]
-      assert_equal true,                locker_instantiate[:poll]
-      assert_equal queues,              locker_instantiate[:queues]
-      assert_equal poll_interval,       locker_instantiate[:poll_interval]
-      assert_equal wait_period,         locker_instantiate[:wait_period]
-      assert_equal maximum_buffer_size, locker_instantiate[:maximum_buffer_size]
-      assert_equal worker_priorities,   locker_instantiate[:worker_priorities]
+      assert_equal listen,                 locker_instantiate[:listen]
+      assert_equal true,                   locker_instantiate[:poll]
+      assert_equal queues,                 locker_instantiate[:queues]
+      assert_equal poll_interval,          locker_instantiate[:poll_interval]
+      assert_equal poll_interval_variance, locker_instantiate[:poll_interval_variance]
+      assert_equal wait_period,            locker_instantiate[:wait_period]
+      assert_equal maximum_buffer_size,    locker_instantiate[:maximum_buffer_size]
+      assert_equal worker_priorities,      locker_instantiate[:worker_priorities]
     end
 
     def assert_locker_started(
@@ -254,6 +256,14 @@ MSG
       it "with #{command} to configure the poll interval" do
         assert_successful_invocation "./#{filename} #{command} 10"
         assert_locker_instantiated(poll_interval: 10)
+        assert_locker_started
+      end
+    end
+
+    ["-j", "--poll-interval-variance"].each do |command|
+      it "with #{command} to configure the poll interval variance" do
+        assert_successful_invocation "./#{filename} #{command} 5"
+        assert_locker_instantiated(poll_interval_variance: 5)
         assert_locker_started
       end
     end

--- a/spec/que/poller_spec.rb
+++ b/spec/que/poller_spec.rb
@@ -275,7 +275,7 @@ describe Que::Poller do
       assert_equal false, poller.should_poll?
     end
 
-    it "should be false if the number of jobs returned from the last poll was less than the lowest priority request, but the poll_interval has elapsed" do
+    it "should be true if the number of jobs returned from the last poll was less than the lowest priority request, but the poll_interval has elapsed" do
       job_ids = 5.times.map { Que::Job.enqueue.que_attrs[:id] }
 
       result = poller.poll(priorities: { 500 => 7 }, held_locks: Set.new)


### PR DESCRIPTION
### Context

We run multiple ECS tasks of que that are all started almost exactly at the same time during every deployment. 

That means that they also start polling at the same time, and continue doing so in such a synchronized fashion.

More specifically, in our case:
- we run 4 que processes
- `poll-interval` is set to 20s

Meaning on average we poll every 5s, but in reality, we poll 4 times every 20s :slightly_smiling_face:

We would like to introduce a random variance to the polling interval, so that the polling is more evenly distributed.

### Changes

Add optional `poll-interval-variance` CLI parameter defaulting to 0.0.

It is used to make each individual poll time slightly randomised, so that tasks started at the same time won't continue polling at the same time.