### PR TITLE
Run tests on Rails 7.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,17 +8,21 @@ jobs:
     strategy:
       matrix:
         ruby_version: ['2.7', '3.0', '3.1', '3.2']
-        rails_gemfile: ['6.0', '6.1', '7.0', '7.1']
+        rails_gemfile: ['6.0', '6.1', '7.0', '7.1', '7.2']
         postgres_version: ['14']
         include:
         # Postgres versions
-        - { ruby_version: '3.2', rails_gemfile: '7.1', postgres_version: '9' }
-        - { ruby_version: '3.2', rails_gemfile: '7.1', postgres_version: '10' }
-        - { ruby_version: '3.2', rails_gemfile: '7.1', postgres_version: '11' }
-        - { ruby_version: '3.2', rails_gemfile: '7.1', postgres_version: '12' }
-        - { ruby_version: '3.2', rails_gemfile: '7.1', postgres_version: '13' }
-        - { ruby_version: '3.2', rails_gemfile: '7.1', postgres_version: '14' }
-        exclude: []
+        - { ruby_version: '3.2', rails_gemfile: '7.2', postgres_version: '9' }
+        - { ruby_version: '3.2', rails_gemfile: '7.2', postgres_version: '10' }
+        - { ruby_version: '3.2', rails_gemfile: '7.2', postgres_version: '11' }
+        - { ruby_version: '3.2', rails_gemfile: '7.2', postgres_version: '12' }
+        - { ruby_version: '3.2', rails_gemfile: '7.2', postgres_version: '13' }
+        - { ruby_version: '3.2', rails_gemfile: '7.2', postgres_version: '14' }
+        exclude: # Rails 7.2 is not compatible with Ruby < 3.1
+        - ruby_version: '2.7'
+          rails_gemfile: '7.2'
+        - ruby_version: '3.0'
+          rails_gemfile: '7.2'
     name: "Test: Ruby ${{ matrix.ruby_version }}, Rails ${{ matrix.rails_gemfile }}, PostgreSQL ${{ matrix.postgres_version }}"
     services:
       db:

--- a/spec/gemfiles/Gemfile-rails-7.2
+++ b/spec/gemfiles/Gemfile-rails-7.2
@@ -1,7 +1,6 @@
-# When adding/changing anything in this file, remember to update the alternate
-# Gemfiles in spec/gemfiles as well!
-
 source 'https://rubygems.org'
+
+gem 'que', path: '../..'
 
 group :development, :test do
   gem 'rake'
@@ -11,21 +10,14 @@ group :development, :test do
   gem 'sequel',          require: nil
   gem 'connection_pool', require: nil
   gem 'pond',            require: nil
-
-  gem 'pg',       require: nil, platform: :ruby
-  gem 'jruby-pg', require: nil, platform: :jruby
+  gem 'pg',              require: nil, platform: :ruby
+  gem 'pg_jruby',        require: nil, platform: :jruby
 end
 
 group :test do
   gem 'minitest',         '~> 5.10.1'
   gem 'minitest-profile', '0.0.2'
   gem 'minitest-hooks',   '1.4.0'
-  gem 'minitest-fail-fast', '0.1.0'
-
-  gem 'm'
-
   gem 'pry'
   gem 'pg_examiner', '~> 0.5.2'
 end
-
-gemspec


### PR DESCRIPTION
This PR is to show that the tests fail on current master because of deprecations in Rails 7.2. 

It's not intended to be merged.

```ruby
  1) Error:
Que::ActiveRecord::Connection::JobMiddleware#test_0001_should clear connections to secondary DBs between jobs:
NoMethodError: undefined method `clear_active_connections!' for SecondDatabaseModel:Class
Did you mean?  clear_validators!
    /opt/hostedtoolcache/Ruby/3.1.6/x64/lib/ruby/gems/3.1.0/gems/activerecord-7.2.1.2/lib/active_record/dynamic_matchers.rb:22:in `method_missing'
    /home/runner/work/que/que/spec/que/active_record/connection_spec.rb:42:in `block (2 levels) in <top (required)>'

  2) Error:
Que::ActiveRecord::Connection::JobMiddleware#test_0002_shouldn't clear connections to secondary DBs between jobs if run_synchronously is enabled :
NoMethodError: undefined method `clear_active_connections!' for SecondDatabaseModel:Class
Did you mean?  clear_validators!
    /opt/hostedtoolcache/Ruby/3.1.6/x64/lib/ruby/gems/3.1.0/gems/activerecord-7.2.1.2/lib/active_record/dynamic_matchers.rb:22:in `method_missing'
    /home/runner/work/que/que/spec/que/active_record/connection_spec.rb:42:in `block (2 levels) in <top (required)>'
```

Fixed in https://github.com/que-rb/que/pull/423, which also includes changes from this PR. 

Close this PR after the above is merged.