### PR TITLE
Add more descriptive error to file loading

### DIFF
--- a/lib/que/command_line_interface.rb
+++ b/lib/que/command_line_interface.rb
@@ -196,13 +196,7 @@ OUTPUT
         end
 
         args.each do |file|
-          begin
-            require file
-          rescue LoadError => e
-            output.puts "Could not load file '#{file}': #{e}"
-            output.puts "Your file path should look like you're running a script, e.g. `./path/to/file.rb`" unless file.start_with?('./')
-            return 1
-          end
+            require File.expand_path(file)
         end
 
         Que.logger ||= Logger.new(STDOUT)

--- a/lib/que/command_line_interface.rb
+++ b/lib/que/command_line_interface.rb
@@ -200,6 +200,7 @@ OUTPUT
             require file
           rescue LoadError => e
             output.puts "Could not load file '#{file}': #{e}"
+            output.puts "Your file path should look like you're running a script, e.g. `./path/to/file.rb`" unless file.start_with?('./')
             return 1
           end
         end

--- a/spec/que/command_line_interface_spec.rb
+++ b/spec/que/command_line_interface_spec.rb
@@ -121,7 +121,7 @@ describe Que::CommandLineInterface do
     it "should infer the default require file if it exists" do
       filename = write_file
 
-      assert_successful_invocation "", default_require_file: "./#{filename}.rb"
+      assert_successful_invocation "", default_require_file: "#{filename}.rb"
 
       assert_equal(
         {filename => true},
@@ -161,29 +161,10 @@ MSG
 
     it "should raise an error if any of the files don't exist" do
       name = write_file
-      code = execute "./#{name} ./nonexistent_file"
-      assert_equal 1, code
-
-      assert_equal ["Could not load file './nonexistent_file': cannot load such file -- ./nonexistent_file"], output.messages
+      assert_raises(LoadError) { execute "#{name} ./nonexistent_file" }
 
       assert_equal(
         {name => true},
-        LOADED_FILES
-      )
-    end
-
-    it "should raise an error if file is not leading with ./" do
-      name = write_file
-      code = execute "#{name}"
-      assert_equal 1, code
-
-      assert_equal [
-        "Could not load file '#{name}': cannot load such file -- #{name}",
-        "Your file path should look like you're running a script, e.g. `./path/to/file.rb`"
-      ], output.messages
-
-      assert_equal(
-        {},
         LOADED_FILES
       )
     end

--- a/spec/que/command_line_interface_spec.rb
+++ b/spec/que/command_line_interface_spec.rb
@@ -171,6 +171,22 @@ MSG
         LOADED_FILES
       )
     end
+
+    it "should raise an error if file is not leading with ./" do
+      name = write_file
+      code = execute "#{name}"
+      assert_equal 1, code
+
+      assert_equal [
+        "Could not load file '#{name}': cannot load such file -- #{name}",
+        "Your file path should look like you're running a script, e.g. `./path/to/file.rb`"
+      ], output.messages
+
+      assert_equal(
+        {},
+        LOADED_FILES
+      )
+    end
   end
 
   describe "should start up a locker" do


### PR DESCRIPTION
After trying to run it locally I found out, that an original error about the unavailability to run a file is not descriptive. So, I decided to add an error to make it more obvious.