### PR TITLE
Resolve 7.1 deprecation warnings

### DIFF
--- a/lib/que/active_record/connection.rb
+++ b/lib/que/active_record/connection.rb
@@ -42,7 +42,7 @@ module Que
             # feature to unknowingly leak connections to other databases. So,
             # take the additional step of telling ActiveRecord to check in all
             # of the current thread's connections after each job is run.
-            ::ActiveRecord::Base.clear_active_connections! unless job.class.resolve_que_setting(:run_synchronously)
+            ::ActiveRecord::Base.connection_handler.clear_active_connections! unless job.class.resolve_que_setting(:run_synchronously)
           end
         end
       end

--- a/spec/que/active_record/connection_spec.rb
+++ b/spec/que/active_record/connection_spec.rb
@@ -39,7 +39,7 @@ if defined?(::ActiveRecord)
         establish_connection(QUE_URL)
       end
 
-      SecondDatabaseModel.clear_active_connections!
+      SecondDatabaseModel.connection_handler.clear_active_connections!
       refute SecondDatabaseModel.connection_handler.active_connections?
 
       class SecondDatabaseModelJob < Que::Job

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -113,7 +113,7 @@ if ENV['USE_RAILS'] == 'true'
     end
 
     class TestLocator
-      def locate(gid)
+      def locate(gid, _options = {})
         gid.model_name.constantize.find(gid.model_id)
       end
     end


### PR DESCRIPTION
A few small tweaks to resolve the new warnings that Rails 7.1 is throwing with the current release of Que (deprecation messages detailed in the relevant Git commit messages)