### PR TITLE
Resolve GlobalID::Locator.locate missing argument warning

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -113,7 +113,7 @@ if ENV['USE_RAILS'] == 'true'
     end
 
     class TestLocator
-      def locate(gid)
+      def locate(gid, _options = {})
         gid.model_name.constantize.find(gid.model_id)
       end
     end


### PR DESCRIPTION
Add in an (unused) `options` arg for the `TestLocator.locate` method to resolve the following deprecation warning thrown by Rails 7.1 when running the test suite:

```
DEPRECATION WARNING: It seems your locator is defining the `locate` method only with one argument. 
Please make sure your locator is receiving the options argument as well, like `locate(gid, options = {})`. 
(called from run at /work/lib/que/active_job/extensions.rb:138)
```

---

Another option would be

```
      def locate(*args)
        args[0].then { |gid| gid.model_name.constantize.find(gid.model_id) }
      end
```

but as the earliest versions of the base `GlobalID::Locator.locate` method have the `options = {}` second argument I think what's in the PR should be fine regardless of the underlying Rails version?