### PR TITLE
Replace md5() with hashtext()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 <!-- MarkdownTOC autolink=true -->
 
+- [Unreleased](#unreleased)
 - [2.4.1 \(2024-10-28\)](#241-2024-10-28)
 - [2.4.0 \(2024-08-21\)](#240-2024-08-21)
 - [2.3.0 \(2023-10-16\)](#230-2023-10-16)
@@ -59,6 +60,25 @@
 - [0.0.1 \(2013-11-07\)](#001-2013-11-07)
 
 <!-- /MarkdownTOC -->
+
+## Unreleased
+
+- **Changed**:
+    + Replaced `md5()` with `hashtext()` in `que_job_notify()` function for PostgreSQL server running in FIPS mode.
+
+This release contains a database migration. You will need to migrate Que to the latest database schema version (8):
+
+```ruby
+class UpdateQueTablesToVersion8 < ActiveRecord::Migration[7.0]
+  def up
+    Que.migrate!(version: 8)
+  end
+
+  def down
+    Que.migrate!(version: 7)
+  end
+end
+```
 
 ## 2.4.1 (2024-10-28)
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ class CreateQueSchema < ActiveRecord::Migration[6.0]
     # Whenever you use Que in a migration, always specify the version you're
     # migrating to. If you're unsure what the current version is, check the
     # changelog.
-    Que.migrate!(version: 7)
+    Que.migrate!(version: 8)
   end
 
   def down

--- a/lib/que/migrations.rb
+++ b/lib/que/migrations.rb
@@ -4,7 +4,7 @@ module Que
   module Migrations
     # In order to ship a schema change, add the relevant up and down sql files
     # to the migrations directory, and bump the version here.
-    CURRENT_VERSION = 7
+    CURRENT_VERSION = 8
 
     class << self
       def migrate!(version:)

--- a/lib/que/migrations/8/down.sql
+++ b/lib/que/migrations/8/down.sql
@@ -1,0 +1,59 @@
+-- Revert hashtext() back to md5()
+CREATE OR REPLACE FUNCTION que_job_notify() RETURNS trigger AS $$
+  DECLARE
+    locker_pid integer;
+    sort_key json;
+  BEGIN
+    -- Don't do anything if the job is scheduled for a future time.
+    IF NEW.run_at IS NOT NULL AND NEW.run_at > now() THEN
+      RETURN null;
+    END IF;
+
+    -- Pick a locker to notify of the job's insertion, weighted by their number
+    -- of workers. Should bounce pseudorandomly between lockers on each
+    -- invocation, hence the md5-ordering, but still touch each one equally,
+    -- hence the modulo using the job_id.
+    SELECT pid
+    INTO locker_pid
+    FROM (
+      SELECT *, last_value(row_number) OVER () + 1 AS count
+      FROM (
+        SELECT *, row_number() OVER () - 1 AS row_number
+        FROM (
+          SELECT *
+          FROM public.que_lockers ql, generate_series(1, ql.worker_count) AS id
+          WHERE
+            listening AND
+            queues @> ARRAY[NEW.queue] AND
+            ql.job_schema_version = NEW.job_schema_version
+          ORDER BY md5(pid::text || id::text)
+        ) t1
+      ) t2
+    ) t3
+    WHERE NEW.id % count = row_number;
+
+    IF locker_pid IS NOT NULL THEN
+      -- There's a size limit to what can be broadcast via LISTEN/NOTIFY, so
+      -- rather than throw errors when someone enqueues a big job, just
+      -- broadcast the most pertinent information, and let the locker query for
+      -- the record after it's taken the lock. The worker will have to hit the
+      -- DB in order to make sure the job is still visible anyway.
+      SELECT row_to_json(t)
+      INTO sort_key
+      FROM (
+        SELECT
+          'job_available' AS message_type,
+          NEW.queue       AS queue,
+          NEW.priority    AS priority,
+          NEW.id          AS id,
+          -- Make sure we output timestamps as UTC ISO 8601
+          to_char(NEW.run_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"') AS run_at
+      ) t;
+
+      PERFORM pg_notify('que_listener_' || locker_pid::text, sort_key::text);
+    END IF;
+
+    RETURN null;
+  END
+$$
+LANGUAGE plpgsql;

--- a/lib/que/migrations/8/up.sql
+++ b/lib/que/migrations/8/up.sql
@@ -1,0 +1,59 @@
+-- Replace md5() with hashtext() for FIPS compliance
+CREATE OR REPLACE FUNCTION que_job_notify() RETURNS trigger AS $$
+  DECLARE
+    locker_pid integer;
+    sort_key json;
+  BEGIN
+    -- Don't do anything if the job is scheduled for a future time.
+    IF NEW.run_at IS NOT NULL AND NEW.run_at > now() THEN
+      RETURN null;
+    END IF;
+
+    -- Pick a locker to notify of the job's insertion, weighted by their number
+    -- of workers. Should bounce pseudorandomly between lockers on each
+    -- invocation, hence the hashtext-ordering, but still touch each one equally,
+    -- hence the modulo using the job_id.
+    SELECT pid
+    INTO locker_pid
+    FROM (
+      SELECT *, last_value(row_number) OVER () + 1 AS count
+      FROM (
+        SELECT *, row_number() OVER () - 1 AS row_number
+        FROM (
+          SELECT *
+          FROM public.que_lockers ql, generate_series(1, ql.worker_count) AS id
+          WHERE
+            listening AND
+            queues @> ARRAY[NEW.queue] AND
+            ql.job_schema_version = NEW.job_schema_version
+          ORDER BY hashtext(pid::text || id::text)
+        ) t1
+      ) t2
+    ) t3
+    WHERE NEW.id % count = row_number;
+
+    IF locker_pid IS NOT NULL THEN
+      -- There's a size limit to what can be broadcast via LISTEN/NOTIFY, so
+      -- rather than throw errors when someone enqueues a big job, just
+      -- broadcast the most pertinent information, and let the locker query for
+      -- the record after it's taken the lock. The worker will have to hit the
+      -- DB in order to make sure the job is still visible anyway.
+      SELECT row_to_json(t)
+      INTO sort_key
+      FROM (
+        SELECT
+          'job_available' AS message_type,
+          NEW.queue       AS queue,
+          NEW.priority    AS priority,
+          NEW.id          AS id,
+          -- Make sure we output timestamps as UTC ISO 8601
+          to_char(NEW.run_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"') AS run_at
+      ) t;
+
+      PERFORM pg_notify('que_listener_' || locker_pid::text, sort_key::text);
+    END IF;
+
+    RETURN null;
+  END
+$$
+LANGUAGE plpgsql;

--- a/spec/que/command_line_interface_spec.rb
+++ b/spec/que/command_line_interface_spec.rb
@@ -2,7 +2,6 @@
 
 require 'spec_helper'
 
-require 'digest/md5'
 require 'que/command_line_interface'
 
 describe Que::CommandLineInterface do
@@ -93,7 +92,7 @@ describe Que::CommandLineInterface do
     # same files will result in spec failures. So instead just generate a new
     # file name for each spec to write/delete.
 
-    name = "spec/temp/file_#{Digest::MD5.hexdigest(rand.to_s)}"
+    name = "spec/temp/file_#{rand}"
     written_files << name
     File.open("#{name}.rb", 'w') { |f| f.puts %(LOADED_FILES["#{name}"] = true) }
     name


### PR DESCRIPTION
Hello. When PostgreSQL 15+ is running in FIPS mode, it has all usage of MD5 disabled. One would see an error message:

```
ERROR -- : [ActiveJob] Failed enqueuing UpdateJob to Que(default): PG::InternalError (ERROR: could not compute MD5 hash: unsupported
```

The culprit seems to be usage of MD5 for load balancing:
https://github.com/que-rb/que/blob/17fb2c3b75b37599bf17043dbb692555f582f249/lib/que/migrations/5/up.sql#L41

I think the solution is to use a hashing algorithm that doesn't bother FIPS. And PostgreSQL's built-in `hashtext()` function seems to check. As far as I understand the exact hashing algorithm is irrelevant.

As a bonus, that `hashtext` function is **5 times** faster than `md5`. On my laptop it shows **142ms** vs **27ms** for 100k iterations.

```
zync=# \timing on
Timing is on.
zync=# SELECT count(distinct md5(n::text)) FROM generate_series(1, 100000) n;
 count  
--------
 100000
(1 row)

Time: 142.511 ms

zync=# SELECT count(distinct hashtext(n::text)) FROM generate_series(1, 100000) n;
 count  
--------
 100000
(1 row)

Time: 27.405 ms
```

-- I tried this on PostgreSQL 15 and 18, but `hashtext` seems to be old so probably will support earlier versions as well.