### PR TITLE
Skip poll based on buffer fullness

### DIFF
--- a/lib/que/command_line_interface.rb
+++ b/lib/que/command_line_interface.rb
@@ -18,15 +18,15 @@ module Que
         default_require_file: RAILS_ENVIRONMENT_FILE
       )
 
-        options                             = {}
-        queues                              = []
-        log_level                           = 'info'
-        log_internals                       = false
-        poll_interval                       = 5
-        poll_buffer_fullness_skip_threshold = 1.0
-        connection_url                      = nil
-        worker_count                        = nil
-        worker_priorities                   = nil
+        options                               = {}
+        queues                                = []
+        log_level                             = 'info'
+        log_internals                         = false
+        poll_interval                         = 5
+        skip_poll_when_buffer_above_threshold = 1.0
+        connection_url                        = nil
+        worker_count                          = nil
+        worker_priorities                     = nil
 
         parser =
           OptionParser.new do |opts|
@@ -52,11 +52,11 @@ module Que
             end
 
             opts.on(
-              '--poll-buffer-fullness-skip-threshold [THRESHOLD]',
+              '--skip-poll-when-buffer-above-threshold [THRESHOLD]',
               Float,
               "Set threshold for skipping polls based on buffer fullness (default: 1.0)",
             ) do |threshold|
-              poll_buffer_fullness_skip_threshold = threshold
+              skip_poll_when_buffer_above_threshold = threshold
             end
 
             opts.on(
@@ -241,8 +241,8 @@ OUTPUT
           options[:queues] = queues_hash
         end
 
-        options[:poll_interval] = poll_interval
-        options[:poll_buffer_fullness_skip_threshold] = poll_buffer_fullness_skip_threshold
+        options[:poll_interval]                          = poll_interval
+        options[:skip_poll_when_buffer_above_threshold]  = skip_poll_when_buffer_above_threshold
 
         locker =
           begin

--- a/lib/que/command_line_interface.rb
+++ b/lib/que/command_line_interface.rb
@@ -18,14 +18,15 @@ module Que
         default_require_file: RAILS_ENVIRONMENT_FILE
       )
 
-        options           = {}
-        queues            = []
-        log_level         = 'info'
-        log_internals     = false
-        poll_interval     = 5
-        connection_url    = nil
-        worker_count      = nil
-        worker_priorities = nil
+        options                             = {}
+        queues                              = []
+        log_level                           = 'info'
+        log_internals                       = false
+        poll_interval                       = 5
+        poll_buffer_fullness_skip_threshold = 1.0
+        connection_url                      = nil
+        worker_count                        = nil
+        worker_priorities                   = nil
 
         parser =
           OptionParser.new do |opts|
@@ -48,6 +49,14 @@ module Que
                 "in seconds (default: 5)",
             ) do |i|
               poll_interval = i
+            end
+
+            opts.on(
+              '--poll-buffer-fullness-skip-threshold [THRESHOLD]',
+              Float,
+              "Set threshold for skipping polls based on buffer fullness (default: 1.0)",
+            ) do |threshold|
+              poll_buffer_fullness_skip_threshold = threshold
             end
 
             opts.on(
@@ -233,6 +242,7 @@ OUTPUT
         end
 
         options[:poll_interval] = poll_interval
+        options[:poll_buffer_fullness_skip_threshold] = poll_buffer_fullness_skip_threshold
 
         locker =
           begin

--- a/lib/que/locker.rb
+++ b/lib/que/locker.rb
@@ -33,7 +33,7 @@ module Que
     }
 
   class Locker
-    attr_reader :thread, :workers, :job_buffer, :locks, :queues, :poll_interval, :poll_buffer_fullness_skip_threshold
+    attr_reader :thread, :workers, :job_buffer, :locks, :queues, :poll_interval, :skip_poll_when_buffer_above_threshold
 
     MESSAGE_RESOLVERS = {}
     RESULT_RESOLVERS  = {}
@@ -47,24 +47,24 @@ module Que
     RESULT_RESOLVERS[:job_finished] =
       -> (messages) { finish_jobs(messages.map{|m| m.fetch(:metajob)}) }
 
-    DEFAULT_POLL_INTERVAL                       = 5.0
-    DEFAULT_POLL_BUFFER_FULLNESS_SKIP_THRESHOLD = 1.0
-    DEFAULT_WAIT_PERIOD                         = 50
-    DEFAULT_MAXIMUM_BUFFER_SIZE                 = 8
-    DEFAULT_WORKER_PRIORITIES                   = [10, 30, 50, nil, nil, nil].freeze
+    DEFAULT_POLL_INTERVAL                         = 5.0
+    DEFAULT_SKIP_POLL_WHEN_BUFFER_ABOVE_THRESHOLD = 1.0
+    DEFAULT_WAIT_PERIOD                           = 50
+    DEFAULT_MAXIMUM_BUFFER_SIZE                   = 8
+    DEFAULT_WORKER_PRIORITIES                     = [10, 30, 50, nil, nil, nil].freeze
 
     def initialize(
-      queues:                              [Que.default_queue],
-      connection_url:                      nil,
-      listen:                              true,
-      poll:                                true,
-      poll_interval:                       DEFAULT_POLL_INTERVAL,
-      poll_buffer_fullness_skip_threshold: DEFAULT_POLL_BUFFER_FULLNESS_SKIP_THRESHOLD,
-      wait_period:                         DEFAULT_WAIT_PERIOD,
-      maximum_buffer_size:                 DEFAULT_MAXIMUM_BUFFER_SIZE,
-      worker_priorities:                   DEFAULT_WORKER_PRIORITIES,
-      on_worker_start:                     nil,
-      pidfile:                             nil
+      queues:                                [Que.default_queue],
+      connection_url:                        nil,
+      listen:                                true,
+      poll:                                  true,
+      poll_interval:                         DEFAULT_POLL_INTERVAL,
+      skip_poll_when_buffer_above_threshold: DEFAULT_SKIP_POLL_WHEN_BUFFER_ABOVE_THRESHOLD,
+      wait_period:                           DEFAULT_WAIT_PERIOD,
+      maximum_buffer_size:                   DEFAULT_MAXIMUM_BUFFER_SIZE,
+      worker_priorities:                     DEFAULT_WORKER_PRIORITIES,
+      on_worker_start:                       nil,
+      pidfile:                               nil
     )
 
       # Sanity-check all our arguments, since some users may instantiate Locker
@@ -96,14 +96,14 @@ module Que
 
       Que.internal_log :locker_instantiate, self do
         {
-          queues:                              queues,
-          listen:                              listen,
-          poll:                                poll,
-          poll_interval:                       poll_interval,
-          poll_buffer_fullness_skip_threshold: poll_buffer_fullness_skip_threshold,
-          wait_period:                         wait_period,
-          maximum_buffer_size:                 maximum_buffer_size,
-          worker_priorities:                   worker_priorities,
+          queues:                                queues,
+          listen:                                listen,
+          poll:                                  poll,
+          poll_interval:                         poll_interval,
+          skip_poll_when_buffer_above_threshold: skip_poll_when_buffer_above_threshold,
+          wait_period:                           wait_period,
+          maximum_buffer_size:                   maximum_buffer_size,
+          worker_priorities:                     worker_priorities,
         }
       end
 
@@ -111,7 +111,7 @@ module Que
       @locks = Set.new
 
       @poll_interval = poll_interval
-      @poll_buffer_fullness_skip_threshold = poll_buffer_fullness_skip_threshold
+      @skip_poll_when_buffer_above_threshold = skip_poll_when_buffer_above_threshold
 
       if queues.is_a?(Hash)
         @queue_names = queues.keys
@@ -335,12 +335,12 @@ module Que
       return unless pollers
 
       # Skip polling if the job buffer is sufficiently full.
-      if job_buffer.size >= job_buffer.maximum_size * poll_buffer_fullness_skip_threshold
+      if job_buffer.size >= job_buffer.maximum_size * skip_poll_when_buffer_above_threshold
         Que.internal_log(:locker_polling_skipped, self) {
           {            
             current_buffer_size: job_buffer.size,
             max_buffer_size: job_buffer.maximum_size,
-            poll_buffer_fullness_skip_threshold: poll_buffer_fullness_skip_threshold,
+            skip_poll_when_buffer_above_threshold: skip_poll_when_buffer_above_threshold,
           }  
         }
 

--- a/lib/que/locker.rb
+++ b/lib/que/locker.rb
@@ -33,7 +33,7 @@ module Que
     }
 
   class Locker
-    attr_reader :thread, :workers, :job_buffer, :locks, :queues, :poll_interval
+    attr_reader :thread, :workers, :job_buffer, :locks, :queues, :poll_interval, :poll_buffer_fullness_skip_threshold
 
     MESSAGE_RESOLVERS = {}
     RESULT_RESOLVERS  = {}
@@ -47,22 +47,24 @@ module Que
     RESULT_RESOLVERS[:job_finished] =
       -> (messages) { finish_jobs(messages.map{|m| m.fetch(:metajob)}) }
 
-    DEFAULT_POLL_INTERVAL       = 5.0
-    DEFAULT_WAIT_PERIOD         = 50
-    DEFAULT_MAXIMUM_BUFFER_SIZE = 8
-    DEFAULT_WORKER_PRIORITIES   = [10, 30, 50, nil, nil, nil].freeze
+    DEFAULT_POLL_INTERVAL                       = 5.0
+    DEFAULT_POLL_BUFFER_FULLNESS_SKIP_THRESHOLD = 1.0
+    DEFAULT_WAIT_PERIOD                         = 50
+    DEFAULT_MAXIMUM_BUFFER_SIZE                 = 8
+    DEFAULT_WORKER_PRIORITIES                   = [10, 30, 50, nil, nil, nil].freeze
 
     def initialize(
-      queues:              [Que.default_queue],
-      connection_url:      nil,
-      listen:              true,
-      poll:                true,
-      poll_interval:       DEFAULT_POLL_INTERVAL,
-      wait_period:         DEFAULT_WAIT_PERIOD,
-      maximum_buffer_size: DEFAULT_MAXIMUM_BUFFER_SIZE,
-      worker_priorities:   DEFAULT_WORKER_PRIORITIES,
-      on_worker_start:     nil,
-      pidfile:             nil
+      queues:                              [Que.default_queue],
+      connection_url:                      nil,
+      listen:                              true,
+      poll:                                true,
+      poll_interval:                       DEFAULT_POLL_INTERVAL,
+      poll_buffer_fullness_skip_threshold: DEFAULT_POLL_BUFFER_FULLNESS_SKIP_THRESHOLD,
+      wait_period:                         DEFAULT_WAIT_PERIOD,
+      maximum_buffer_size:                 DEFAULT_MAXIMUM_BUFFER_SIZE,
+      worker_priorities:                   DEFAULT_WORKER_PRIORITIES,
+      on_worker_start:                     nil,
+      pidfile:                             nil
     )
 
       # Sanity-check all our arguments, since some users may instantiate Locker
@@ -94,13 +96,14 @@ module Que
 
       Que.internal_log :locker_instantiate, self do
         {
-          queues:              queues,
-          listen:              listen,
-          poll:                poll,
-          poll_interval:       poll_interval,
-          wait_period:         wait_period,
-          maximum_buffer_size: maximum_buffer_size,
-          worker_priorities:   worker_priorities,
+          queues:                              queues,
+          listen:                              listen,
+          poll:                                poll,
+          poll_interval:                       poll_interval,
+          poll_buffer_fullness_skip_threshold: poll_buffer_fullness_skip_threshold,
+          wait_period:                         wait_period,
+          maximum_buffer_size:                 maximum_buffer_size,
+          worker_priorities:                   worker_priorities,
         }
       end
 
@@ -108,6 +111,7 @@ module Que
       @locks = Set.new
 
       @poll_interval = poll_interval
+      @poll_buffer_fullness_skip_threshold = poll_buffer_fullness_skip_threshold
 
       if queues.is_a?(Hash)
         @queue_names = queues.keys
@@ -330,11 +334,21 @@ module Que
       # enabled).
       return unless pollers
 
+      # Skip polling if the job buffer is sufficiently full.
+      if job_buffer.size >= job_buffer.maximum_size * poll_buffer_fullness_skip_threshold
+        Que.internal_log(:locker_polling_skipped, self) {
+          {            
+            current_buffer_size: job_buffer.size,
+            max_buffer_size: job_buffer.maximum_size,
+            poll_buffer_fullness_skip_threshold: poll_buffer_fullness_skip_threshold,
+          }  
+        }
+
+        return
+      end
+
       # Figure out what job priorities we have to fill.
       priorities = job_buffer.available_priorities
-
-      # Only poll when there are workers ready for jobs.
-      return if priorities.empty?
 
       all_metajobs = []
 

--- a/spec/que/locker_spec.rb
+++ b/spec/que/locker_spec.rb
@@ -435,7 +435,7 @@ describe Que::Locker do
       
       locker_settings[:worker_priorities] = [100, 100, 100]
       locker_settings[:maximum_buffer_size] = 8
-      locker_settings[:poll_buffer_fullness_skip_threshold] = 0.75
+      locker_settings[:skip_poll_when_buffer_above_threshold] = 0.75
 
       locker
       3.times { $q1.pop }

--- a/spec/que/locker_spec.rb
+++ b/spec/que/locker_spec.rb
@@ -429,6 +429,39 @@ describe Que::Locker do
 
       locker.stop!
     end
+
+    it "should skip polling if the buffer is sufficiently full" do
+      ids = 12.times.map { BlockJob.enqueue(job_options: { priority: 100 }).que_attrs[:id] }
+      
+      locker_settings[:worker_priorities] = [100, 100, 100]
+      locker_settings[:maximum_buffer_size] = 8
+      locker_settings[:poll_buffer_fullness_skip_threshold] = 0.75
+
+      locker
+      3.times { $q1.pop }
+
+      # Should have polled once
+      locker_polled_events = internal_messages(event: 'poller_polled')
+      assert_equal 1, locker_polled_events.size
+
+      # Should have locked first 11 only because there are 8 buffer slots and 3 open workers
+      assert_equal ids[0...11], locked_ids
+
+      # Pretend to have worked 1 job to drop buffer to 7/8 full, should skip polling
+      $q2.push nil
+      sleep_until do 
+        locker_polling_skipped_events = internal_messages(event: 'locker_polling_skipped')
+        locker_polling_skipped_events.any?
+      end
+
+      # No new polling events should have occurred
+      locker_polled_events = internal_messages(event: 'poller_polled')
+      assert_equal 1, locker_polled_events.size
+
+      3.times { $q2.push nil }
+
+      locker.stop!
+    end
   end
 
   describe "when receiving a NOTIFY of a new job" do


### PR DESCRIPTION
### Context

During high-throughput spike periods, Que's job polling mechanism can lead to very high database load with continuous polling, even when the job buffer is already nearly full and workers are actively processing jobs.

What is possible to be happening currently:
- locker accepts enough jobs via listen to fill the buffer
- the jobs are super fast, so in the few milliseconds in between [wait](https://github.com/que-rb/que/blob/17fb2c3b75b37599bf17043dbb692555f582f249/lib/que/locker.rb#L309) and next [poll](https://github.com/que-rb/que/blob/17fb2c3b75b37599bf17043dbb692555f582f249/lib/que/locker.rb#L301) we have already worked a few
- poller polls for a very few jobs to fill the buffer fully
- locker accept more jobs via listen immediately (and potentially displaces any polled low-importance jobs)
- workers work a few jobs again
- the previous poll was [satisfied?](https://github.com/que-rb/que/blob/17fb2c3b75b37599bf17043dbb692555f582f249/lib/que/poller.rb#L160), so poller polls again immediately (potentially for the same low-importance jobs again)

### Changes

Add optional `skip-poll-when-buffer-above-threshold` CLI parameter defaulting to 1.0.

When the buffer already has at least `skip-poll-when-buffer-above-threshold` fraction of its capacity filled, the polling is skipped for that iteration.

### Backward-compatibility

Currently, the polling is skipped only when the buffer is completely full.

When the new `skip-poll-when-buffer-above-threshold` parameter is not provided, it defaults to 1.0 so there's no change compared to the current behaviour.
