### PR TITLE
Dockerfile: use bookworm instead of buster since buster is past EOL 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.2.2-slim-buster@sha256:005f0892d160a4f80f8f89116ec15fddc81f296cd4083db9d59accaed125e270 AS base
+FROM ruby:3.2.2-slim-bookworm@sha256:b1b1636eb4e9d3499fc6166f54f7bb96d792e005b887091346fd1ae01ad97229 AS base
 
 # Install libpq-dev in our base layer, as it's needed in all environments
 RUN apt-get update \


### PR DESCRIPTION
Update dockerfile to use Bookworm instead of Buster, since Buster is [past EOL](https://wiki.debian.org/DebianReleases#Versions_of_Debian_stable) and running tests locally will fail. 

```
 > [dev base 2/3] RUN apt-get update   && apt-get install -y libpq-dev   && rm -rf /var/lib/apt/lists/*:                            
0.585 Ign:1 http://deb.debian.org/debian buster InRelease                                                                           
0.825 Ign:2 http://deb.debian.org/debian-security buster/updates InRelease                                                          
0.833 Ign:3 http://deb.debian.org/debian buster-updates InRelease                                                                   
0.840 Err:4 http://deb.debian.org/debian buster Release
0.840   404  Not Found [IP: 151.101.2.132 80]
1.082 Err:5 http://deb.debian.org/debian-security buster/updates Release
1.082   404  Not Found [IP: 151.101.2.132 80]
1.099 Err:6 http://deb.debian.org/debian buster-updates Release
1.099   404  Not Found [IP: 151.101.2.132 80]
1.109 Reading package lists...
1.126 E: The repository 'http://deb.debian.org/debian buster Release' does not have a Release file.
1.126 E: The repository 'http://deb.debian.org/debian-security buster/updates Release' does not have a Release file.
1.126 E: The repository 'http://deb.debian.org/debian buster-updates Release' does not have a Release file.
```

