### PR TITLE
Add rails 8 and 8.1 to Github Actions Test Matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         ruby_version: ['2.7', '3.0', '3.1', '3.2']
-        rails_gemfile: ['6.0', '6.1', '7.0', '7.1', '7.2']
+        rails_gemfile: ['6.0', '6.1', '7.0', '7.1', '7.2', '8.0', '8.1']
         postgres_version: ['14']
         include:
         # Postgres versions
@@ -18,11 +18,17 @@ jobs:
         - { ruby_version: '3.2', rails_gemfile: '7.2', postgres_version: '12' }
         - { ruby_version: '3.2', rails_gemfile: '7.2', postgres_version: '13' }
         - { ruby_version: '3.2', rails_gemfile: '7.2', postgres_version: '14' }
-        exclude: # Rails 7.2 is not compatible with Ruby < 3.1
+        - { ruby_version: '3.2', rails_gemfile: '8.0', postgres_version: '14' }
+        - { ruby_version: '3.2', rails_gemfile: '8.1', postgres_version: '14' }
+        exclude: 
+          # Rails 7.2 is not compatible with Ruby < 3.1
+          # Rails 8.0 is not compatible with Ruby < 3.2
         - ruby_version: '2.7'
-          rails_gemfile: '7.2'
+          rails_gemfile: ['7.2','8.0','8.1']
         - ruby_version: '3.0'
-          rails_gemfile: '7.2'
+          rails_gemfile: ['7.2','8.0','8.1']
+        - ruby_version: '3.1'
+          rails_gemfile: ['8.0','8.1']
     name: "Test: Ruby ${{ matrix.ruby_version }}, Rails ${{ matrix.rails_gemfile }}, PostgreSQL ${{ matrix.postgres_version }}"
     services:
       db:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,23 +12,31 @@ jobs:
         postgres_version: ['14']
         include:
         # Postgres versions
-        - { ruby_version: '3.2', rails_gemfile: '7.2', postgres_version: '9' }
-        - { ruby_version: '3.2', rails_gemfile: '7.2', postgres_version: '10' }
-        - { ruby_version: '3.2', rails_gemfile: '7.2', postgres_version: '11' }
-        - { ruby_version: '3.2', rails_gemfile: '7.2', postgres_version: '12' }
-        - { ruby_version: '3.2', rails_gemfile: '7.2', postgres_version: '13' }
-        - { ruby_version: '3.2', rails_gemfile: '7.2', postgres_version: '14' }
-        - { ruby_version: '3.2', rails_gemfile: '8.0', postgres_version: '14' }
+        - { ruby_version: '3.2', rails_gemfile: '8.1', postgres_version: '9' }
+        - { ruby_version: '3.2', rails_gemfile: '8.1', postgres_version: '10' }
+        - { ruby_version: '3.2', rails_gemfile: '8.1', postgres_version: '11' }
+        - { ruby_version: '3.2', rails_gemfile: '8.1', postgres_version: '12' }
+        - { ruby_version: '3.2', rails_gemfile: '8.1', postgres_version: '13' }
         - { ruby_version: '3.2', rails_gemfile: '8.1', postgres_version: '14' }
         exclude: 
           # Rails 7.2 is not compatible with Ruby < 3.1
           # Rails 8.0 is not compatible with Ruby < 3.2
         - ruby_version: '2.7'
-          rails_gemfile: ['7.2','8.0','8.1']
+          rails_gemfile: '7.2'
+        - ruby_version: '2.7'
+          rails_gemfile: '8.0'
+        - ruby_version: '2.7'
+          rails_gemfile: '8.1'
         - ruby_version: '3.0'
-          rails_gemfile: ['7.2','8.0','8.1']
+          rails_gemfile: '7.2'
+        - ruby_version: '3.0'
+          rails_gemfile: '8.0'
+        - ruby_version: '3.0'
+          rails_gemfile: '8.1'
         - ruby_version: '3.1'
-          rails_gemfile: ['8.0','8.1']
+          rails_gemfile: '8.0'
+        - ruby_version: '3.1'
+          rails_gemfile: '8.1'
     name: "Test: Ruby ${{ matrix.ruby_version }}, Rails ${{ matrix.rails_gemfile }}, PostgreSQL ${{ matrix.postgres_version }}"
     services:
       db:

--- a/spec/gemfiles/Gemfile-rails-8.0
+++ b/spec/gemfiles/Gemfile-rails-8.0
@@ -1,0 +1,23 @@
+source 'https://rubygems.org'
+
+gem 'que', path: '../..'
+
+group :development, :test do
+  gem 'rake'
+
+  gem 'activerecord',    '~> 8.0.0', require: nil
+  gem 'activejob',       '~> 8.0.0', require: nil
+  gem 'sequel',          require: nil
+  gem 'connection_pool', require: nil
+  gem 'pond',            require: nil
+  gem 'pg',              require: nil, platform: :ruby
+  gem 'pg_jruby',        require: nil, platform: :jruby
+end
+
+group :test do
+  gem 'minitest',         '~> 5.10.1'
+  gem 'minitest-profile', '0.0.2'
+  gem 'minitest-hooks',   '1.4.0'
+  gem 'pry'
+  gem 'pg_examiner', '~> 0.5.2'
+end

--- a/spec/gemfiles/Gemfile-rails-8.1
+++ b/spec/gemfiles/Gemfile-rails-8.1
@@ -1,0 +1,23 @@
+source 'https://rubygems.org'
+
+gem 'que', path: '../..'
+
+group :development, :test do
+  gem 'rake'
+
+  gem 'activerecord',    '~> 8.1.0', require: nil
+  gem 'activejob',       '~> 8.1.0', require: nil
+  gem 'sequel',          require: nil
+  gem 'connection_pool', require: nil
+  gem 'pond',            require: nil
+  gem 'pg',              require: nil, platform: :ruby
+  gem 'pg_jruby',        require: nil, platform: :jruby
+end
+
+group :test do
+  gem 'minitest',         '~> 5.10.1'
+  gem 'minitest-profile', '0.0.2'
+  gem 'minitest-hooks',   '1.4.0'
+  gem 'pry'
+  gem 'pg_examiner', '~> 0.5.2'
+end


### PR DESCRIPTION
Add Rails 8 and 8.1 to Github Actions Test Matrix

This may be more of a "for discussion PR" as it may be preferable to 
- stop testing some older rails and ruby versions, for less of a combinatorial explosion, or
- have more of a combinatorial explosion by adding more options (newer ruby, newer postgres). 

In either case, I'm happy to make those changes at maintainer's suggestions. There may be an opportunity to fiddle with the inclusion/exclusion design for it to be less unwieldy (some ideas in this [thread](https://github.com/orgs/community/discussions/7835)).