### PR TITLE
Ruby 3.4 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,8 @@ jobs:
         - { ruby_version: '3.2', rails_gemfile: '7.2', postgres_version: '12' }
         - { ruby_version: '3.2', rails_gemfile: '7.2', postgres_version: '13' }
         - { ruby_version: '3.2', rails_gemfile: '7.2', postgres_version: '14' }
+        - { ruby_version: '3.3', rails_gemfile: '7.2', postgres_version: '14' }
+        - { ruby_version: '3.4', rails_gemfile: '7.2', postgres_version: '14' }
         exclude: # Rails 7.2 is not compatible with Ruby < 3.1
         - ruby_version: '2.7'
           rails_gemfile: '7.2'

--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ group :development, :test do
 end
 
 group :test do
-  gem 'minitest',         '~> 5.10.1'
+  gem 'minitest',         '~> 5.25.0'
   gem 'minitest-profile', '0.0.2'
   gem 'minitest-hooks',   '1.4.0'
   gem 'minitest-fail-fast', '0.1.0'

--- a/spec/gemfiles/Gemfile-rails-6.0
+++ b/spec/gemfiles/Gemfile-rails-6.0
@@ -15,7 +15,7 @@ group :development, :test do
 end
 
 group :test do
-  gem 'minitest',         '~> 5.10.1'
+  gem 'minitest',         '~> 5.25.0'
   gem 'minitest-profile', '0.0.2'
   gem 'minitest-hooks',   '1.4.0'
   gem 'pry'

--- a/spec/gemfiles/Gemfile-rails-6.1
+++ b/spec/gemfiles/Gemfile-rails-6.1
@@ -15,7 +15,7 @@ group :development, :test do
 end
 
 group :test do
-  gem 'minitest',         '~> 5.10.1'
+  gem 'minitest',         '~> 5.25.0'
   gem 'minitest-profile', '0.0.2'
   gem 'minitest-hooks',   '1.4.0'
   gem 'pry'

--- a/spec/gemfiles/Gemfile-rails-7.0
+++ b/spec/gemfiles/Gemfile-rails-7.0
@@ -15,7 +15,7 @@ group :development, :test do
 end
 
 group :test do
-  gem 'minitest',         '~> 5.10.1'
+  gem 'minitest',         '~> 5.25.0'
   gem 'minitest-profile', '0.0.2'
   gem 'minitest-hooks',   '1.4.0'
   gem 'pry'

--- a/spec/gemfiles/Gemfile-rails-7.1
+++ b/spec/gemfiles/Gemfile-rails-7.1
@@ -15,7 +15,7 @@ group :development, :test do
 end
 
 group :test do
-  gem 'minitest',         '~> 5.10.1'
+  gem 'minitest',         '~> 5.25.0'
   gem 'minitest-profile', '0.0.2'
   gem 'minitest-hooks',   '1.4.0'
   gem 'pry'

--- a/spec/gemfiles/Gemfile-rails-7.2
+++ b/spec/gemfiles/Gemfile-rails-7.2
@@ -15,7 +15,7 @@ group :development, :test do
 end
 
 group :test do
-  gem 'minitest',         '~> 5.10.1'
+  gem 'minitest',         '~> 5.25.0'
   gem 'minitest-profile', '0.0.2'
   gem 'minitest-hooks',   '1.4.0'
   gem 'pry'

--- a/spec/que/command_line_interface_spec.rb
+++ b/spec/que/command_line_interface_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-require 'digest/md5'
+require 'securerandom'
 require 'que/command_line_interface'
 
 describe Que::CommandLineInterface do
@@ -93,7 +93,13 @@ describe Que::CommandLineInterface do
     # same files will result in spec failures. So instead just generate a new
     # file name for each spec to write/delete.
 
-    name = "spec/temp/file_#{Digest::MD5.hexdigest(rand.to_s)}"
+    # This can't use Kernel#rand, because minitest 5.16 and up call
+    # `srand Minitest.seed` before shuffling each suite's methods, so the
+    # global PRNG replays the same sequence once per describe block. Two specs
+    # in different blocks would then be given the same file name, and the
+    # second `require` of it does nothing - the path is already in
+    # $LOADED_FEATURES - leaving LOADED_FILES without an entry for it.
+    name = "spec/temp/file_#{SecureRandom.hex(16)}"
     written_files << name
     File.open("#{name}.rb", 'w') { |f| f.puts %(LOADED_FILES["#{name}"] = true) }
     name

--- a/spec/que/listener_spec.rb
+++ b/spec/que/listener_spec.rb
@@ -273,10 +273,13 @@ describe Que::Listener do
 
         assert_instance_of Que::Error, error
 
+        # Inspected rather than written out, so that the expectation holds on
+        # Rubies that inspect hashes differently - 3.4 prints {priority: 90}
+        # where earlier versions print {:priority=>90}.
         expected_message = [
           "Message of type 'job_available' doesn't match format!",
-          "Message: {:priority=>90, :queue=>\"queue_name\", :run_at=>\"2017-06-30T18:33:35.425307Z\"}",
-          "Format: {:id=>Integer, :priority=>Integer, :queue=>String, :run_at=>/\\A\\d{4}\\-\\d{2}\\-\\d{2}T\\d{2}:\\d{2}:\\d{2}.\\d{6}Z\\z/}",
+          "Message: #{{priority: 90, queue: "queue_name", run_at: "2017-06-30T18:33:35.425307Z"}.inspect}",
+          "Format: #{{id: Integer, priority: Integer, queue: String, run_at: /\A\d{4}\-\d{2}\-\d{2}T\d{2}:\d{2}:\d{2}.\d{6}Z\z/}.inspect}",
         ].join("\n")
 
         assert_equal expected_message, error.message


### PR DESCRIPTION
Adds Ruby 3.3 and 3.4 to CI and fixes the three things that stood in the way.

1. mutex_m removal broke suite loading

Ruby 3.4 removed mutex_m from the standard library. The pinned minitest ~> 5.10.1 requires it, so the suite failed before a single test ran. minitest ~> 5.25.0 has no such dependency and still supports Ruby 2.7, so one pin covers the whole existing matrix — bumped in the root Gemfile and in all five spec/gemfiles/Gemfile-rails-*.

2. Hash#inspect changed its rendering

Ruby 3.4 renders symbol keys as {key: 1} rather than {:key=>1}. listener_spec hardcoded the old rendering of a hash that Que::Listener inspects into an error message. Deriving the expectation with #inspect instead of writing it out makes it hold on every Ruby version.

3. Temp spec file names collided under the newer minitest (9f10965)

This one is a prerequisite for the bump rather than a Ruby 3.4 issue, so it's a separate commit.

minitest 5.16 added srand Minitest.seed to Test.runnable_methods, which runs once per suite — so from that version on, the global PRNG replays the same sequence at the start of every describe block. command_line_interface_spec's write_file built its file name from Digest::MD5.hexdigest(rand.to_s), so specs in different describe blocks were handed the same name. The second require of that path is a no-op — it's already in $LOADED_FEATURES — so LOADED_FILES never gets an entry for it and the assertions on it fail.

Which specs collide moves around with the seed, so the failures read as flakes rather than as a bug. Under minitest 5.25, every one of six seeds tried produced between one and three of them. Switching to SecureRandom.hex(16) fixes it, as SecureRandom is unaffected by srand.

CI

Adds { ruby: 3.3, rails: 7.2, postgres: 14 } and { ruby: 3.4, rails: 7.2, postgres: 14 }. Rails 7.2 only — the older Rails gemfiles are already excluded from the newer Rubies they don't support.